### PR TITLE
feat(pwa): show install banner only after onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
+import { AnimatePresence } from 'motion/react';
 import { useEffect, useState } from 'react';
 import { BottomNav } from '@/components/BottomNav';
-import { type BeforeInstallPromptEvent, InstallBanner } from '@/components/InstallBanner';
+import { InstallBanner } from '@/components/InstallBanner';
 import { isOnboardingDone, markOnboardingDone, markOnboardingUndone } from '@/lib/onboarding';
+import { type BeforeInstallPromptEvent, shouldShowInstallBanner } from '@/lib/pwa';
 import { Dashboard } from '@/pages/Dashboard';
 import { LogPrayers } from '@/pages/LogPrayers';
 import { OnboardingFlow } from '@/pages/OnboardingFlow';
@@ -70,9 +72,11 @@ export function App() {
 	return (
 		<div className="min-h-dvh" style={{ background: '#1A1A1C' }}>
 			<main className="mx-auto max-w-lg pt-4 pb-28">{pages[activeTab]}</main>
-			{!showOnboarding && installPrompt && (
-				<InstallBanner prompt={installPrompt} onDismiss={() => setInstallPrompt(null)} />
-			)}
+			<AnimatePresence>
+				{!showOnboarding && installPrompt && shouldShowInstallBanner() && (
+					<InstallBanner prompt={installPrompt} onDismiss={() => setInstallPrompt(null)} />
+				)}
+			</AnimatePresence>
 			<BottomNav activeTab={activeTab} onTabChange={setActiveTab} />
 		</div>
 	);

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -1,10 +1,6 @@
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
-
-export interface BeforeInstallPromptEvent extends Event {
-	prompt: () => Promise<void>;
-	userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-}
+import { useState } from 'react';
+import { type BeforeInstallPromptEvent, dismissInstallBanner } from '@/lib/pwa';
 
 interface InstallBannerProps {
 	prompt: BeforeInstallPromptEvent;
@@ -12,54 +8,28 @@ interface InstallBannerProps {
 }
 
 export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
-	const [visible, setVisible] = useState(false);
 	const [isPrompting, setIsPrompting] = useState(false);
-
-	useEffect(() => {
-		// Don't show if already dismissed
-		if (localStorage.getItem('pwa-install-dismissed') === 'true') {
-			return;
-		}
-
-		// Don't show if already installed (standalone mode)
-		if (window.matchMedia('(display-mode: standalone)').matches) {
-			return;
-		}
-
-		// Show banner
-		setVisible(true);
-	}, []);
 
 	const handleInstall = async () => {
 		setIsPrompting(true);
 		try {
 			await prompt.prompt();
-			const { outcome } = await prompt.userChoice;
-			if (outcome === 'accepted') {
-				// User accepted install
-				localStorage.setItem('pwa-install-dismissed', 'true');
-				setVisible(false);
-				onDismiss();
-			} else {
-				// User dismissed
-				localStorage.setItem('pwa-install-dismissed', 'true');
-				setVisible(false);
-				onDismiss();
-			}
+			await prompt.userChoice;
+			dismissInstallBanner();
+			onDismiss();
 		} catch (error) {
 			console.error('Install prompt failed:', error);
+			dismissInstallBanner();
+			onDismiss();
 		} finally {
 			setIsPrompting(false);
 		}
 	};
 
 	const handleDismiss = () => {
-		localStorage.setItem('pwa-install-dismissed', 'true');
-		setVisible(false);
+		dismissInstallBanner();
 		onDismiss();
 	};
-
-	if (!visible) return null;
 
 	return (
 		<motion.div

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,0 +1,24 @@
+export const PWA_INSTALL_DISMISSED_KEY = 'pwa-install-dismissed';
+
+export interface BeforeInstallPromptEvent extends Event {
+	prompt: () => Promise<void>;
+	userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export function shouldShowInstallBanner(): boolean {
+	// Don't show if already dismissed
+	if (localStorage.getItem(PWA_INSTALL_DISMISSED_KEY) === 'true') {
+		return false;
+	}
+
+	// Don't show if already installed (standalone mode)
+	if (window.matchMedia('(display-mode: standalone)').matches) {
+		return false;
+	}
+
+	return true;
+}
+
+export function dismissInstallBanner(): void {
+	localStorage.setItem(PWA_INSTALL_DISMISSED_KEY, 'true');
+}


### PR DESCRIPTION
## Summary

• Add BeforeInstallPromptEvent interface for type-safe beforeinstallprompt event handling
• Create InstallBanner component with motion animations (spring transition)
• Check localStorage and standalone mode to avoid duplicate prompts
• Position banner above BottomNav with gold "Installer" and secondary "Plus tard" buttons
• Capture beforeinstallprompt event in App.tsx and render InstallBanner conditionally
• Only show banner after onboarding is complete

## Type

feat