### PR TITLE
feat(onboarding): add skip buttons for WelcomeStep and DebtStep

### DIFF
--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -174,9 +174,6 @@ function WelcomeStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
 					onClick={onSkip}
 					className="text-sm py-2"
 					style={{ color: '#4A4A4C' }}
-					initial={{ opacity: 0, y: 12 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ delay: 0.44, ...spring }}
 					whileTap={{ scale: 0.95 }}
 				>
 					Passer la configuration
@@ -528,7 +525,7 @@ function DebtStep({
 
 			<AnimatePresence>{saveError && <ErrorBanner message={saveError} />}</AnimatePresence>
 
-			<div className="mt-auto">
+			<div className="mt-auto flex flex-col gap-3">
 				<motion.button
 					type="button"
 					onClick={handleSubmit}


### PR DESCRIPTION
## Summary

• Add "Passer la configuration" link to WelcomeStep — calls `onComplete()` directly, bypassing all onboarding
• Add "Passer cette étape" button to DebtStep — advances to ObjectiveStep without saving any debt (debt stays 0)
• Consistent skip button style across WelcomeStep and DebtStep, matching existing ObjectiveStep pattern

## Type

feat

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now skip the welcome setup and debt configuration steps during onboarding via new skip buttons, letting them advance the flow without saving those steps.
* **Style / Layout**
  * Action areas updated with improved spacing to accommodate the new skip buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->