### PR TITLE
fix(stats): fix biased avgPerDay estimation for new users

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -314,7 +314,9 @@ describe('getStats', () => {
 			session_id: null,
 		});
 		const stats = await queries.getStats(db);
-		// logsInWindow = thisMonth (only the log from today, 3), effectiveDays = 30
+		expect(stats.thisMonth).toBe(3);
+		expect(stats.allTime).toBe(4);
+		// logsInWindow = logs within effective 30-day window (only today), effectiveDays = 30
 		expect(stats.avgPerDay).toBeCloseTo(3 / 30);
 	});
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -148,8 +148,14 @@ async function getTemporalStats(db: QadaDB): Promise<{
 			Math.floor((now.getTime() - firstLogDate.getTime()) / 86_400_000),
 		);
 		const effectiveDays = Math.min(daysSinceFirst, 30);
-		const logsInWindow = effectiveDays < 30 ? allTime : thisMonth;
-		avgPerDay = logsInWindow / effectiveDays;
+		const windowStart = new Date(now);
+		windowStart.setDate(windowStart.getDate() - effectiveDays);
+		let logsInWindow = 0;
+		for (const log of all) {
+			const logDate = new Date(log.logged_at);
+			if (logDate >= windowStart) logsInWindow += log.quantity;
+		}
+		avgPerDay = logsInWindow > 0 ? logsInWindow / effectiveDays : 0;
 	}
 
 	return { today, thisWeek, thisMonth, allTime, avgPerDay };


### PR DESCRIPTION
## Summary

• Use actual history duration (capped at 30 days) as divisor instead of hardcoded 30
• New users now get accurate daily average estimation
• Added tests for users with <30 days and ≥30 days history

## Type

fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating average-per-day calculations across single-day, multi-day, and capped 30-day history scenarios.

* **Bug Fixes**
  * Improved statistics computation to track first log date, apply a 30-day history cap, and compute average daily metrics using the effective window for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->