### PR TITLE
feat(pwa): version check via /version.json with update dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ export function App() {
 					/>
 				)}
 			</AnimatePresence>
-			<AlertDialog open={!showOnboarding && updateAvailable}>
+			<AlertDialog open={!showOnboarding && updateAvailable && !needRefresh}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
 						<AlertDialogTitle>{t('updateBanner.title')}</AlertDialogTitle>

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -5,6 +5,7 @@ const POLL_INTERVAL_MS = 5 * 60 * 1000;
 export function useVersionCheck(): { updateAvailable: boolean; dismiss: () => void } {
 	const [updateAvailable, setUpdateAvailable] = useState(false);
 	const currentVersionRef = useRef<string | null>(null);
+	const latestVersionRef = useRef<string | null>(null);
 	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
 	useEffect(() => {
@@ -21,6 +22,7 @@ export function useVersionCheck(): { updateAvailable: boolean; dismiss: () => vo
 				}
 
 				if (data.version !== currentVersionRef.current) {
+					latestVersionRef.current = data.version;
 					setUpdateAvailable(true);
 				}
 			} catch {
@@ -58,5 +60,12 @@ export function useVersionCheck(): { updateAvailable: boolean; dismiss: () => vo
 		};
 	}, []);
 
-	return { updateAvailable, dismiss: () => setUpdateAvailable(false) };
+	function dismiss() {
+		if (latestVersionRef.current !== null) {
+			currentVersionRef.current = latestVersionRef.current;
+		}
+		setUpdateAvailable(false);
+	}
+
+	return { updateAvailable, dismiss };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
 			workbox: {
 				globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
 				cleanupOutdatedCaches: true,
+				navigateFallbackDenylist: [/^\/version\.json$/],
 			},
 			devOptions: {
 				enabled: true,


### PR DESCRIPTION
## Summary

• Implement network-based version checking via /version.json endpoint
• Add 5-minute polling with Page Visibility API pause/resume
• Display AlertDialog when new version is available
• Generate version.json at build time (excluded from Service Worker cache)

## Type

feat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App update notifications now display in a modal dialog. The app checks for new versions periodically in the background, pausing checks when your browser tab is inactive. Choose to update immediately or dismiss and continue working.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->