### PR TITLE
feat(session): manual sujood button as fallback when sensor unsupported

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -519,7 +519,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 									if (sujoodCount === 0) {
 										navigator.vibrate?.(100);
 										setSujoodCount(1);
-									} else {
+									} else if (!busyRef.current) {
 										navigator.vibrate?.([50, 50, 150]);
 										setSujoodCount(0);
 										handleAutoIncrement();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,7 +73,6 @@
 		"progress": "PROGRESS",
 		"sujood1": "✋ Waiting for 1st sujood",
 		"sujood2": "✋ Waiting for 2nd sujood",
-		"sensorUnsupported": "Sensor mode not supported — use the \"Done\" button",
 		"manualSujood1": "1st sujood",
 		"manualSujood2": "2nd sujood",
 		"done": "DONE ✓",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -73,7 +73,6 @@
 		"progress": "PROGRESSION",
 		"sujood1": "✋ Attente du 1er sujood",
 		"sujood2": "✋ Attente du 2ème sujood",
-		"sensorUnsupported": "Mode capteur non supporté — utilisez le bouton \"Terminé\"",
 		"manualSujood1": "1er sujoud",
 		"manualSujood2": "2ème sujoud",
 		"done": "TERMINÉ ✓",


### PR DESCRIPTION
## Summary

• Replace sensor unsupported banner with interactive manual sujood button
• Double-tap flow: 1st sujood (dark bg) → 2nd sujood (gold bg, pulsing) → auto-increment
• Haptic feedback on each tap (100ms for 1st, [50,50,150] pattern for 2nd)
• Supports both tap and accessibility

## Type

feat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the sensor unavailable message with an interactive button for manual session control
  * Button provides haptic feedback and visual state changes on each tap
  * Session progress automatically advances when button is activated
  * Added English and French translations for improved accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->