### PR TITLE
feat(sensor): DeviceOrientationEvent fallback for sujood detection on Chrome

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -317,7 +317,10 @@ export function Session({ onClose }: { onClose: () => void }) {
 	}, [phase]);
 
 	async function handleStart() {
-		if (typeof (DeviceOrientationEvent as any).requestPermission === 'function') {
+		if (
+			typeof DeviceOrientationEvent !== 'undefined' &&
+			typeof (DeviceOrientationEvent as any).requestPermission === 'function'
+		) {
 			try {
 				await (DeviceOrientationEvent as any).requestPermission();
 			} catch {}

--- a/src/hooks/useProximitySensor.test.ts
+++ b/src/hooks/useProximitySensor.test.ts
@@ -142,10 +142,11 @@ describe('useProximitySensor', () => {
 		}
 
 		beforeEach(() => {
-			vi.useFakeTimers({ toFake: ['Date'], now: PINNED_NOW });
+			vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'], now: PINNED_NOW });
 		});
 
 		afterEach(() => {
+			vi.runAllTimers();
 			delete (window as any).DeviceOrientationEvent;
 		});
 
@@ -230,6 +231,48 @@ describe('useProximitySensor', () => {
 			unmount();
 
 			expect(removeSpy).toHaveBeenCalledWith('deviceorientation', expect.any(Function));
+		});
+
+		it('falls back to unsupported after 3s startup timeout with no events', () => {
+			(window as any).DeviceOrientationEvent = class {};
+			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			expect(result.current.isSupported).toBe(true);
+
+			act(() => vi.advanceTimersByTime(3000));
+
+			expect(result.current.isSupported).toBe(false);
+			expect(result.current.currentState).toBe('unsupported');
+		});
+
+		it('cancels startup timeout once baseline is captured', () => {
+			(window as any).DeviceOrientationEvent = class {};
+			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			act(() => dispatchOrientation(10)); // baseline captured → timer cleared
+			act(() => vi.advanceTimersByTime(3000));
+
+			expect(result.current.isSupported).toBe(true);
+		});
+
+		it('resets sujood-down state after 5s without returning to baseline', () => {
+			(window as any).DeviceOrientationEvent = class {};
+			const onFirst = vi.fn();
+			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
+
+			act(() => dispatchOrientation(10)); // baseline = 10
+			act(() => dispatchOrientation(65)); // delta = 55 → sujood down at PINNED_NOW
+			vi.setSystemTime(PINNED_NOW + 5001);
+			act(() => dispatchOrientation(12)); // elapsed > 5000 → reset, no callback
+
+			expect(onFirst).not.toHaveBeenCalled();
+
+			// A fresh sujood sequence now works
+			act(() => dispatchOrientation(65)); // delta = 55 → new sujood down
+			vi.setSystemTime(PINNED_NOW + 5500);
+			act(() => dispatchOrientation(12)); // delta = 2 < 25, elapsed 499ms → fires
+
+			expect(onFirst).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -8,6 +8,13 @@ interface UseProximitySensorResult {
 	currentState: SensorState;
 }
 
+const TILT_DOWN_THRESHOLD = 50;
+const TILT_RETURN_THRESHOLD = 25;
+const MIN_SUJOOD_DURATION_MS = 300;
+const MAX_SUJOOD_DURATION_MS = 5000;
+const DEBOUNCE_MS = 800;
+const ORIENTATION_STARTUP_TIMEOUT_MS = 3000;
+
 export function useProximitySensor(
 	active: boolean,
 	onFirstSujood: () => void,
@@ -50,15 +57,13 @@ export function useProximitySensor(
 		sujoodCountRef.current = 0;
 		betaBaselineRef.current = null;
 		sujoodDownTimeRef.current = 0;
+		let cancelled = false;
 
 		function handleProximityDetection(isNear: boolean) {
-			if (!isNear) return;
+			if (!isNear || cancelled) return;
 
 			const now = Date.now();
-			const timeSinceLastDetection = now - lastDetectionRef.current;
-
-			if (timeSinceLastDetection < 800) return;
-
+			if (now - lastDetectionRef.current < DEBOUNCE_MS) return;
 			lastDetectionRef.current = now;
 
 			if (sujoodCountRef.current === 0) {
@@ -72,8 +77,10 @@ export function useProximitySensor(
 			}
 		}
 
-		function setupCleanup() {
+		function setupCleanup(extraCleanup?: () => void) {
 			return () => {
+				cancelled = true;
+				extraCleanup?.();
 				if (sensorRef.current) {
 					try {
 						if (typeof sensorRef.current.stop === 'function') {
@@ -127,9 +134,19 @@ export function useProximitySensor(
 
 		// Fallback to DeviceOrientationEvent (Chrome Android, iOS 13+)
 		function setupDeviceOrientationFallback() {
+			const startupTimer = setTimeout(() => {
+				if (cancelled) return;
+				setIsSupported(false);
+				setCurrentState('unsupported');
+				window.removeEventListener('deviceorientation', handleDeviceOrientation);
+				sensorRef.current = null;
+			}, ORIENTATION_STARTUP_TIMEOUT_MS);
+
 			function handleDeviceOrientation(event: DeviceOrientationEvent) {
+				if (cancelled) return;
+
 				if (event.beta === null) {
-					// No real orientation sensor (desktop) — fall back to manual
+					clearTimeout(startupTimer);
 					setIsSupported(false);
 					setCurrentState('unsupported');
 					window.removeEventListener('deviceorientation', handleDeviceOrientation);
@@ -138,6 +155,7 @@ export function useProximitySensor(
 				}
 
 				if (betaBaselineRef.current === null) {
+					clearTimeout(startupTimer);
 					betaBaselineRef.current = event.beta;
 					return;
 				}
@@ -145,12 +163,14 @@ export function useProximitySensor(
 				const delta = Math.abs(event.beta - betaBaselineRef.current);
 
 				if (sujoodDownTimeRef.current === 0) {
-					if (delta > 50) {
+					if (delta > TILT_DOWN_THRESHOLD) {
 						sujoodDownTimeRef.current = Date.now();
 					}
 				} else {
 					const elapsed = Date.now() - sujoodDownTimeRef.current;
-					if (delta < 25 && elapsed >= 300) {
+					if (elapsed > MAX_SUJOOD_DURATION_MS) {
+						sujoodDownTimeRef.current = 0;
+					} else if (delta < TILT_RETURN_THRESHOLD && elapsed >= MIN_SUJOOD_DURATION_MS) {
 						sujoodDownTimeRef.current = 0;
 						handleProximityDetection(true);
 					}
@@ -159,14 +179,17 @@ export function useProximitySensor(
 
 			window.addEventListener('deviceorientation', handleDeviceOrientation);
 			sensorRef.current = handleDeviceOrientation;
+
+			return () => clearTimeout(startupTimer);
 		}
 
 		if (typeof (window as any).ondeviceproximity !== 'undefined') {
 			setupDeviceProximityFallback();
-		} else {
-			setupDeviceOrientationFallback();
+			return setupCleanup();
 		}
-		return setupCleanup();
+
+		const timerCleanup = setupDeviceOrientationFallback();
+		return setupCleanup(timerCleanup);
 	}, [active]);
 
 	return {


### PR DESCRIPTION
## Summary

- `ProximitySensor` was silently removed from Chrome 70 (2018) — Chrome users saw no auto-detection and fell back to the manual button
- Adds `DeviceOrientationEvent` as a 3rd fallback layer in `useProximitySensor`: captures beta baseline at session start, detects sujood when `|beta − baseline| > 50°`, confirms completion on return `< 25°` after ≥300ms
- Desktop Chrome (events with `beta: null`) is correctly detected and falls back to the manual button — no regression
- iOS 13+ permission (`DeviceOrientationEvent.requestPermission()`) is requested at the "Démarrer" tap in `Session.tsx`
- Hook return interface `{ isSupported, isActive, currentState }` is unchanged — `Session.tsx` requires no structural changes

## Test plan

- [x] 128 tests pass (`pnpm test`)
- [x] Build clean (`pnpm run build`)
- [x] 9 new tests covering: support detection, desktop fallback (null beta), baseline capture, sujood detection sequence, minimum 300ms duration guard, two-sujood sequence, listener cleanup
- [ ] Manual: test on Chrome Android — verify sujood auto-detection fires
- [ ] Manual: test on iOS 13+ — verify permission prompt appears on session start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device orientation permission request handling to support motion-based detection during sessions.
  * Implemented device orientation as a fallback detection method when proximity sensors are unavailable.
  * Enhanced prayer movement detection with threshold-based and timing-aware recognition logic.

* **Tests**
  * Extended test coverage for device orientation support and motion detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->