### PR TITLE
feat(settings): changelog page accessible from version row

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -1,0 +1,245 @@
+import { ChevronLeft } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+
+interface ChangelogEntry {
+	version: string;
+	date: string;
+	changes: { fr: string[]; en: string[] };
+}
+
+const ENTRIES: ChangelogEntry[] = [
+	{
+		version: '1.0.18',
+		date: '2026-03-20',
+		changes: {
+			fr: [
+				'Détection automatique des sujouds sur Chrome via le gyroscope',
+				'Basculement vers bouton manuel si capteur indisponible (desktop, iOS refusé)',
+				'Demande de permission gyroscope sur iOS 13+ au démarrage de session',
+			],
+			en: [
+				'Automatic sujood detection on Chrome via gyroscope',
+				'Falls back to manual button when sensor unavailable (desktop, iOS denied)',
+				'Gyroscope permission requested on iOS 13+ at session start',
+			],
+		},
+	},
+	{
+		version: '1.0.16',
+		date: '2026-03-20',
+		changes: {
+			fr: [
+				"Calendrier d'activité style GitHub (16 semaines)",
+				"Détail des sessions dans l'historique (durée, prières)",
+				"Raccourcis PWA : Logger et Stats depuis l'écran d'accueil",
+			],
+			en: [
+				'GitHub-style activity calendar (16 weeks)',
+				'Session details in history (duration, prayers)',
+				'PWA shortcuts: Logger and Stats from home screen',
+			],
+		},
+	},
+	{
+		version: '1.0.15',
+		date: '2026-03-20',
+		changes: {
+			fr: ["Rappel quotidien déplacé dans l'onglet Session des réglages"],
+			en: ['Daily reminder moved to the Session tab in settings'],
+		},
+	},
+	{
+		version: '1.0.14',
+		date: '2026-03-20',
+		changes: {
+			fr: [
+				'Jalons : animation de célébration toutes les 100 prières',
+				"Graphique d'évolution de la dette",
+				'Rappel quotidien configurable',
+				"Dialogue de mise à jour de l'app",
+			],
+			en: [
+				'Milestones: celebration animation every 100 prayers',
+				'Debt evolution chart',
+				'Configurable daily reminder',
+				'In-app update dialog',
+			],
+		},
+	},
+	{
+		version: '1.0.13',
+		date: '2026-03-20',
+		changes: {
+			fr: ['Durée de rattrapage estimée sur la carte stats'],
+			en: ['Estimated catch-up duration on the stats card'],
+		},
+	},
+	{
+		version: '1.0.12',
+		date: '2026-03-20',
+		changes: {
+			fr: [
+				'Durée de rattrapage affichée dans le tableau de bord',
+				'Sections collapsibles dans les réglages',
+			],
+			en: ['Catch-up duration shown on the dashboard', 'Collapsible sections in settings'],
+		},
+	},
+	{
+		version: '1.0.10',
+		date: '2026-03-16',
+		changes: {
+			fr: ['Bouton manuel pour compter les sujouds si le capteur est indisponible'],
+			en: ['Manual button to count sujoods when sensor is unavailable'],
+		},
+	},
+	{
+		version: '1.0.8',
+		date: '2026-03-16',
+		changes: {
+			fr: ["Refonte de la tuile d'estimation en carte pleine largeur"],
+			en: ['Estimation tile redesigned as full-width card'],
+		},
+	},
+	{
+		version: '1.0.6',
+		date: '2026-03-16',
+		changes: {
+			fr: [
+				'Vérification de mise à jour automatique',
+				'Notification de nouvelle version disponible',
+			],
+			en: ['Automatic update check', 'Notification for new version available'],
+		},
+	},
+	{
+		version: '1.0.5',
+		date: '2026-03-16',
+		changes: {
+			fr: [
+				'Réglages réorganisés en onglets (Dette, Session, App)',
+				'Sections collapsibles dans les réglages',
+			],
+			en: [
+				'Settings reorganized into tabs (Debt, Session, App)',
+				'Collapsible sections in settings',
+			],
+		},
+	},
+	{
+		version: '1.0.3',
+		date: '2026-03-16',
+		changes: {
+			fr: ['Support multilingue : français et anglais'],
+			en: ['Multilingual support: French and English'],
+		},
+	},
+	{
+		version: '1.0.1',
+		date: '2026-03-16',
+		changes: {
+			fr: ['Sauvegarde et restauration des données (export/import JSON)'],
+			en: ['Data backup and restore (JSON export/import)'],
+		},
+	},
+	{
+		version: '1.0.0',
+		date: '2026-03-16',
+		changes: {
+			fr: [
+				'Lancement initial',
+				'Session de rattrapage avec détection automatique des sujouds',
+				'Détection de proximité pour le comptage mains-libres',
+				"Maintien de l'écran allumé pendant la session",
+				'Paramétrage de la dette et des objectifs',
+				'Statistiques et historique',
+			],
+			en: [
+				'Initial release',
+				'Catch-up session with automatic sujood detection',
+				'Proximity sensor for hands-free counting',
+				'Screen wake lock during session',
+				'Debt and goal configuration',
+				'Statistics and history',
+			],
+		},
+	},
+];
+
+interface Props {
+	onClose: () => void;
+}
+
+export function Changelog({ onClose }: Props) {
+	const { i18n, t } = useTranslation();
+	const lang = i18n.language.startsWith('fr') ? 'fr' : 'en';
+
+	return (
+		<motion.div
+			className="fixed inset-0 z-50 flex flex-col"
+			style={{ background: '#1A1A1C' }}
+			initial={{ x: '100%' }}
+			animate={{ x: 0 }}
+			exit={{ x: '100%' }}
+			transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+		>
+			{/* Header */}
+			<div
+				className="flex items-center gap-3 px-4 py-4"
+				style={{ borderBottom: '1px solid #2A2A2C' }}
+			>
+				<button
+					type="button"
+					onClick={onClose}
+					className="flex items-center justify-center rounded-full p-2"
+					style={{ background: '#242426' }}
+				>
+					<ChevronLeft size={20} style={{ color: '#F5F5F0' }} />
+				</button>
+				<span className="text-base font-semibold tracking-wide" style={{ color: '#F5F5F0' }}>
+					{t('settings.changelog')}
+				</span>
+			</div>
+
+			{/* Entries */}
+			<div className="flex-1 overflow-y-auto px-4 py-4">
+				<div className="mx-auto flex max-w-lg flex-col gap-4">
+					{ENTRIES.map((entry) => (
+						<div
+							key={entry.version}
+							className="rounded-[20px] px-5 py-4"
+							style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+						>
+							<div className="mb-3 flex items-baseline justify-between">
+								<span className="text-sm font-bold tracking-wide" style={{ color: '#C9A962' }}>
+									v{entry.version}
+								</span>
+								<span className="text-xs" style={{ color: '#4A4A4C' }}>
+									{new Date(`${entry.date}T00:00:00`).toLocaleDateString(i18n.language, {
+										day: 'numeric',
+										month: 'short',
+										year: 'numeric',
+									})}
+								</span>
+							</div>
+							<ul className="flex flex-col gap-1.5">
+								{entry.changes[lang].map((change) => (
+									<li key={change} className="flex items-start gap-2">
+										<span
+											className="mt-1.5 h-1 w-1 shrink-0 rounded-full"
+											style={{ background: '#6E6E70' }}
+										/>
+										<span className="text-sm leading-relaxed" style={{ color: '#A0A0A4' }}>
+											{change}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					))}
+				</div>
+			</div>
+		</motion.div>
+	);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,6 +139,7 @@
 		"language": "LANGUAGE",
 		"application": "APPLICATION",
 		"version": "Version",
+		"changelog": "What's New",
 		"dangerZone": "DANGER ZONE",
 		"resetAll": "RESET ALL DATA",
 		"resetDialogTitle": "Reset everything?",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -139,6 +139,7 @@
 		"language": "LANGUE",
 		"application": "APPLICATION",
 		"version": "Version",
+		"changelog": "Nouveautés",
 		"dangerZone": "ZONE DANGER",
 		"resetAll": "RÉINITIALISER TOUTES LES DONNÉES",
 		"resetDialogTitle": "Tout réinitialiser ?",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,8 @@
-import { ChevronDown, Download, RotateCcw, Trash2, Upload } from 'lucide-react';
+import { ChevronDown, ChevronRight, Download, RotateCcw, Trash2, Upload } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Changelog } from '@/components/Changelog';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -100,6 +101,7 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 
 	const [activeTab, setActiveTab] = useState<Tab>('debt');
 	const [debtMode, setDebtMode] = useState<DebtMode>('years');
+	const [showChangelog, setShowChangelog] = useState(false);
 
 	const [years, setYears] = useState('');
 	const [excludedDays, setExcludedDays] = useState('0');
@@ -216,241 +218,308 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 	];
 
 	return (
-		<div className="flex flex-col gap-5 px-7 pb-4 pt-1">
-			<h1 className="font-display text-3xl font-normal" style={{ color: '#F5F5F0' }}>
-				{t('settings.title')}
-			</h1>
+		<>
+			<AnimatePresence>
+				{showChangelog && <Changelog onClose={() => setShowChangelog(false)} />}
+			</AnimatePresence>
+			<div className="flex flex-col gap-5 px-7 pb-4 pt-1">
+				<h1 className="font-display text-3xl font-normal" style={{ color: '#F5F5F0' }}>
+					{t('settings.title')}
+				</h1>
 
-			{/* Tab bar */}
-			<div
-				className="flex gap-1 rounded-[20px] p-1"
-				style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
-			>
-				{TABS.map(({ value, label }) => (
-					<button
-						key={value}
-						type="button"
-						onClick={() => setActiveTab(value)}
-						className="flex-1 rounded-[16px] py-2.5 text-[11px] font-semibold tracking-[1.5px] transition-colors"
-						style={
-							activeTab === value
-								? { background: '#C9A962', color: '#1A1A1C' }
-								: { color: '#4A4A4C' }
-						}
-					>
-						{label}
-					</button>
-				))}
-			</div>
-
-			{/* Tab content */}
-			<AnimatePresence mode="wait" initial={false}>
-				<motion.div
-					key={activeTab}
-					initial={{ opacity: 0, y: 6 }}
-					animate={{ opacity: 1, y: 0 }}
-					exit={{ opacity: 0, y: -6 }}
-					transition={{ duration: 0.15 }}
-					className="flex flex-col gap-5"
+				{/* Tab bar */}
+				<div
+					className="flex gap-1 rounded-[20px] p-1"
+					style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
 				>
-					{/* ── DETTE tab ── */}
-					{activeTab === 'debt' && (
-						<>
-							{/* Merged debt section */}
-							<CollapsibleSection label={t('settings.calculateDebt')} defaultOpen={true}>
-								<div
-									className="flex flex-col gap-4 rounded-[20px] p-5"
-									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-								>
-									{/* Mode switcher */}
-									<div className="flex gap-2">
-										{(['years', 'manual'] as DebtMode[]).map((mode) => (
-											<button
-												key={mode}
-												type="button"
-												onClick={() => setDebtMode(mode)}
-												className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
-												style={
-													debtMode === mode
-														? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
-														: {
-																background: '#1A1A1C',
-																border: '1px solid #3A3A3C',
-																color: '#4A4A4C',
-															}
-												}
-											>
-												{mode === 'years' ? t('settings.debtByYears') : t('settings.debtManual')}
-											</button>
-										))}
-									</div>
+					{TABS.map(({ value, label }) => (
+						<button
+							key={value}
+							type="button"
+							onClick={() => setActiveTab(value)}
+							className="flex-1 rounded-[16px] py-2.5 text-[11px] font-semibold tracking-[1.5px] transition-colors"
+							style={
+								activeTab === value
+									? { background: '#C9A962', color: '#1A1A1C' }
+									: { color: '#4A4A4C' }
+							}
+						>
+							{label}
+						</button>
+					))}
+				</div>
 
-									<div style={{ height: 1, background: '#2A2A2C' }} />
+				{/* Tab content */}
+				<AnimatePresence mode="wait" initial={false}>
+					<motion.div
+						key={activeTab}
+						initial={{ opacity: 0, y: 6 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, y: -6 }}
+						transition={{ duration: 0.15 }}
+						className="flex flex-col gap-5"
+					>
+						{/* ── DETTE tab ── */}
+						{activeTab === 'debt' && (
+							<>
+								{/* Merged debt section */}
+								<CollapsibleSection label={t('settings.calculateDebt')} defaultOpen={true}>
+									<div
+										className="flex flex-col gap-4 rounded-[20px] p-5"
+										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+									>
+										{/* Mode switcher */}
+										<div className="flex gap-2">
+											{(['years', 'manual'] as DebtMode[]).map((mode) => (
+												<button
+													key={mode}
+													type="button"
+													onClick={() => setDebtMode(mode)}
+													className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
+													style={
+														debtMode === mode
+															? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
+															: {
+																	background: '#1A1A1C',
+																	border: '1px solid #3A3A3C',
+																	color: '#4A4A4C',
+																}
+													}
+												>
+													{mode === 'years' ? t('settings.debtByYears') : t('settings.debtManual')}
+												</button>
+											))}
+										</div>
 
-									{/* By years content */}
-									{debtMode === 'years' && (
-										<>
-											<div className="grid grid-cols-2 gap-3">
-												<div className="flex flex-col gap-1.5">
-													<label
-														htmlFor="input-years"
-														className="text-xs font-medium"
-														style={{ color: '#6E6E70' }}
+										<div style={{ height: 1, background: '#2A2A2C' }} />
+
+										{/* By years content */}
+										{debtMode === 'years' && (
+											<>
+												<div className="grid grid-cols-2 gap-3">
+													<div className="flex flex-col gap-1.5">
+														<label
+															htmlFor="input-years"
+															className="text-xs font-medium"
+															style={{ color: '#6E6E70' }}
+														>
+															{t('settings.missedYears')}
+														</label>
+														<input
+															id="input-years"
+															type="number"
+															value={years}
+															onChange={(e) => setYears(e.target.value)}
+															placeholder={t('settings.yearsPlaceholder')}
+															min="0"
+															step="0.5"
+															style={inputStyle}
+														/>
+													</div>
+													<div className="flex flex-col gap-1.5">
+														<label
+															htmlFor="input-excluded"
+															className="text-xs font-medium"
+															style={{ color: '#6E6E70' }}
+														>
+															{t('settings.excludedDays')}
+														</label>
+														<input
+															id="input-excluded"
+															type="number"
+															value={excludedDays}
+															onChange={(e) => setExcludedDays(e.target.value)}
+															placeholder="0"
+															min="0"
+															style={inputStyle}
+														/>
+													</div>
+												</div>
+
+												<div style={{ height: 1, background: '#2A2A2C' }} />
+												<div className="flex items-center justify-between">
+													<div className="flex flex-col gap-0.5">
+														<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
+															{t('settings.female')}
+														</span>
+														<span className="text-[11px]" style={{ color: '#6E6E70' }}>
+															{t('settings.femaleDesc')}
+														</span>
+													</div>
+													<button
+														type="button"
+														role="switch"
+														aria-checked={isFemme}
+														aria-label={t('settings.female')}
+														onClick={() => setIsFemme((v) => !v)}
+														className="relative h-7 w-12 rounded-full transition-colors"
+														style={{ background: isFemme ? '#C9A962' : '#3A3A3C' }}
 													>
-														{t('settings.missedYears')}
-													</label>
-													<input
-														id="input-years"
-														type="number"
-														value={years}
-														onChange={(e) => setYears(e.target.value)}
-														placeholder={t('settings.yearsPlaceholder')}
-														min="0"
-														step="0.5"
-														style={inputStyle}
-													/>
+														<span
+															className="absolute top-1 h-5 w-5 rounded-full transition-all"
+															style={{
+																background: '#F5F5F0',
+																left: isFemme ? '50%' : '4px',
+															}}
+														/>
+													</button>
 												</div>
-												<div className="flex flex-col gap-1.5">
-													<label
-														htmlFor="input-excluded"
-														className="text-xs font-medium"
-														style={{ color: '#6E6E70' }}
-													>
-														{t('settings.excludedDays')}
-													</label>
-													<input
-														id="input-excluded"
-														type="number"
-														value={excludedDays}
-														onChange={(e) => setExcludedDays(e.target.value)}
-														placeholder="0"
-														min="0"
-														style={inputStyle}
-													/>
-												</div>
-											</div>
 
-											<div style={{ height: 1, background: '#2A2A2C' }} />
-											<div className="flex items-center justify-between">
-												<div className="flex flex-col gap-0.5">
-													<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
-														{t('settings.female')}
-													</span>
-													<span className="text-[11px]" style={{ color: '#6E6E70' }}>
-														{t('settings.femaleDesc')}
-													</span>
-												</div>
+												{isFemme && (
+													<div className="flex flex-col gap-1.5">
+														<label
+															htmlFor="input-hayd"
+															className="text-xs font-medium"
+															style={{ color: '#6E6E70' }}
+														>
+															{t('settings.haydAvg')}
+														</label>
+														<input
+															id="input-hayd"
+															type="number"
+															value={avgHaydDays}
+															onChange={(e) => setAvgHaydDays(e.target.value)}
+															placeholder="6"
+															min="1"
+															max="15"
+															style={inputStyle}
+														/>
+														{parseFloat(years) > 0 && (
+															<p className="text-[11px]" style={{ color: '#6E9E6E' }}>
+																{t('settings.haydDeducted', {
+																	deducted: haydExclusion,
+																	total: totalExcluded,
+																})}
+															</p>
+														)}
+													</div>
+												)}
+
 												<button
 													type="button"
-													role="switch"
-													aria-checked={isFemme}
-													aria-label={t('settings.female')}
-													onClick={() => setIsFemme((v) => !v)}
-													className="relative h-7 w-12 rounded-full transition-colors"
-													style={{ background: isFemme ? '#C9A962' : '#3A3A3C' }}
+													onClick={handleSetDebtFromYears}
+													disabled={!years || parseFloat(years) <= 0}
+													className="flex w-full items-center justify-center rounded-3xl py-3 text-[13px] font-semibold tracking-[1.5px] transition-opacity disabled:opacity-30"
+													style={{
+														background: 'linear-gradient(135deg, #C9A962, #8B7845)',
+														color: '#1A1A1C',
+													}}
 												>
-													<span
-														className="absolute top-1 h-5 w-5 rounded-full transition-all"
-														style={{
-															background: '#F5F5F0',
-															left: isFemme ? '50%' : '4px',
-														}}
-													/>
+													{t('settings.apply')}
 												</button>
-											</div>
+											</>
+										)}
 
-											{isFemme && (
-												<div className="flex flex-col gap-1.5">
-													<label
-														htmlFor="input-hayd"
-														className="text-xs font-medium"
-														style={{ color: '#6E6E70' }}
-													>
-														{t('settings.haydAvg')}
-													</label>
-													<input
-														id="input-hayd"
-														type="number"
-														value={avgHaydDays}
-														onChange={(e) => setAvgHaydDays(e.target.value)}
-														placeholder="6"
-														min="1"
-														max="15"
-														style={inputStyle}
-													/>
-													{parseFloat(years) > 0 && (
-														<p className="text-[11px]" style={{ color: '#6E9E6E' }}>
-															{t('settings.haydDeducted', {
-																deducted: haydExclusion,
-																total: totalExcluded,
-															})}
-														</p>
-													)}
-												</div>
-											)}
-
-											<button
-												type="button"
-												onClick={handleSetDebtFromYears}
-												disabled={!years || parseFloat(years) <= 0}
-												className="flex w-full items-center justify-center rounded-3xl py-3 text-[13px] font-semibold tracking-[1.5px] transition-opacity disabled:opacity-30"
-												style={{
-													background: 'linear-gradient(135deg, #C9A962, #8B7845)',
-													color: '#1A1A1C',
-												}}
-											>
-												{t('settings.apply')}
-											</button>
-										</>
-									)}
-
-									{/* Manual content */}
-									{debtMode === 'manual' && (
-										<>
-											<div className="flex flex-col">
-												{PRAYER_NAMES.map((prayer, i) => {
-													const cfg = PRAYER_CONFIG[prayer];
-													return (
-														<div key={prayer}>
-															{i > 0 && <div style={{ height: 1, background: '#2A2A2C' }} />}
-															<div className="flex items-center gap-3 py-3">
-																<span
-																	className="w-20 font-display text-base font-medium"
-																	style={{ color: cfg.hex }}
-																>
-																	{cfg.labelFr}
-																</span>
-																<span
-																	className="w-12 text-right text-sm"
-																	style={{ color: '#6E6E70' }}
-																>
-																	{debts[prayer]?.remaining ?? 0}
-																</span>
-																<input
-																	type="number"
-																	className="flex-1"
-																	value={manualAmounts[prayer] ?? ''}
-																	onChange={(e) =>
-																		setManualAmounts((prev) => ({
-																			...prev,
-																			[prayer]: e.target.value,
-																		}))
-																	}
-																	placeholder={t('settings.newTotal')}
-																	min="0"
-																	style={{ ...inputStyle, height: 36, fontSize: 13 }}
-																/>
+										{/* Manual content */}
+										{debtMode === 'manual' && (
+											<>
+												<div className="flex flex-col">
+													{PRAYER_NAMES.map((prayer, i) => {
+														const cfg = PRAYER_CONFIG[prayer];
+														return (
+															<div key={prayer}>
+																{i > 0 && <div style={{ height: 1, background: '#2A2A2C' }} />}
+																<div className="flex items-center gap-3 py-3">
+																	<span
+																		className="w-20 font-display text-base font-medium"
+																		style={{ color: cfg.hex }}
+																	>
+																		{cfg.labelFr}
+																	</span>
+																	<span
+																		className="w-12 text-right text-sm"
+																		style={{ color: '#6E6E70' }}
+																	>
+																		{debts[prayer]?.remaining ?? 0}
+																	</span>
+																	<input
+																		type="number"
+																		className="flex-1"
+																		value={manualAmounts[prayer] ?? ''}
+																		onChange={(e) =>
+																			setManualAmounts((prev) => ({
+																				...prev,
+																				[prayer]: e.target.value,
+																			}))
+																		}
+																		placeholder={t('settings.newTotal')}
+																		min="0"
+																		style={{ ...inputStyle, height: 36, fontSize: 13 }}
+																	/>
+																</div>
 															</div>
-														</div>
-													);
-												})}
-											</div>
+														);
+													})}
+												</div>
 
+												<button
+													type="button"
+													onClick={handleApplyAllManual}
+													disabled={!hasManualChanges}
+													className="flex w-full items-center justify-center rounded-3xl py-3 text-[13px] font-semibold tracking-[1.5px] transition-opacity disabled:opacity-30"
+													style={{
+														background: 'linear-gradient(135deg, #C9A962, #8B7845)',
+														color: '#1A1A1C',
+													}}
+												>
+													{t('settings.apply')}
+												</button>
+											</>
+										)}
+									</div>
+								</CollapsibleSection>
+
+								{/* Objective */}
+								<CollapsibleSection label={t('settings.objective')} defaultOpen={true}>
+									<div
+										className="flex flex-col gap-4 rounded-[20px] p-5"
+										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+									>
+										{activeObjective && (
+											<p className="text-xs" style={{ color: '#6E6E70' }}>
+												{t('settings.currentObjective', {
+													target: activeObjective.target,
+													period: t(
+														`common.${activeObjective.period === 'daily' ? 'day' : activeObjective.period === 'weekly' ? 'week' : 'month'}`,
+													),
+												})}
+											</p>
+										)}
+										<div className="flex gap-2">
+											{PERIODS.map(({ value, label }) => (
+												<button
+													type="button"
+													key={value}
+													onClick={() => setObjPeriod(value)}
+													className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
+													style={
+														objPeriod === value
+															? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
+															: {
+																	background: '#1A1A1C',
+																	border: '1px solid #3A3A3C',
+																	color: '#4A4A4C',
+																}
+													}
+												>
+													{label}
+												</button>
+											))}
+										</div>
+										<div className="flex gap-2">
+											<input
+												type="number"
+												value={objTarget}
+												onChange={(e) => setObjTarget(e.target.value)}
+												placeholder={t('settings.targetPlaceholder')}
+												min="1"
+												style={{ ...inputStyle, flex: 1 }}
+											/>
 											<button
 												type="button"
-												onClick={handleApplyAllManual}
-												disabled={!hasManualChanges}
-												className="flex w-full items-center justify-center rounded-3xl py-3 text-[13px] font-semibold tracking-[1.5px] transition-opacity disabled:opacity-30"
+												onClick={handleSetObjective}
+												disabled={!objTarget}
+												className="rounded-[22px] px-6 text-[13px] font-bold transition-opacity disabled:opacity-30"
 												style={{
 													background: 'linear-gradient(135deg, #C9A962, #8B7845)',
 													color: '#1A1A1C',
@@ -458,236 +527,286 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 											>
 												{t('settings.apply')}
 											</button>
-										</>
-									)}
-								</div>
-							</CollapsibleSection>
+										</div>
+									</div>
+								</CollapsibleSection>
+							</>
+						)}
 
-							{/* Objective */}
-							<CollapsibleSection label={t('settings.objective')} defaultOpen={true}>
-								<div
-									className="flex flex-col gap-4 rounded-[20px] p-5"
-									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-								>
-									{activeObjective && (
-										<p className="text-xs" style={{ color: '#6E6E70' }}>
-											{t('settings.currentObjective', {
-												target: activeObjective.target,
-												period: t(
-													`common.${activeObjective.period === 'daily' ? 'day' : activeObjective.period === 'weekly' ? 'week' : 'month'}`,
-												),
-											})}
-										</p>
-									)}
-									<div className="flex gap-2">
-										{PERIODS.map(({ value, label }) => (
-											<button
-												type="button"
-												key={value}
-												onClick={() => setObjPeriod(value)}
-												className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
-												style={
-													objPeriod === value
-														? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
-														: {
-																background: '#1A1A1C',
-																border: '1px solid #3A3A3C',
-																color: '#4A4A4C',
-															}
-												}
-											>
-												{label}
-											</button>
-										))}
-									</div>
-									<div className="flex gap-2">
-										<input
-											type="number"
-											value={objTarget}
-											onChange={(e) => setObjTarget(e.target.value)}
-											placeholder={t('settings.targetPlaceholder')}
-											min="1"
-											style={{ ...inputStyle, flex: 1 }}
-										/>
-										<button
-											type="button"
-											onClick={handleSetObjective}
-											disabled={!objTarget}
-											className="rounded-[22px] px-6 text-[13px] font-bold transition-opacity disabled:opacity-30"
-											style={{
-												background: 'linear-gradient(135deg, #C9A962, #8B7845)',
-												color: '#1A1A1C',
-											}}
-										>
-											{t('settings.apply')}
-										</button>
-									</div>
-								</div>
-							</CollapsibleSection>
-						</>
-					)}
-
-					{/* ── SESSION tab ── */}
-					{activeTab === 'session' && (
-						<>
-							<CollapsibleSection label={t('settings.session')} defaultOpen={true}>
-								<div
-									className="flex flex-col gap-4 rounded-[20px] p-5"
-									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-								>
-									<div className="flex flex-col gap-1">
-										<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
-											{t('settings.prayerOrder')}
-										</span>
-										<span className="text-[11px]" style={{ color: '#6E6E70' }}>
-											{t('settings.prayerOrderDesc')}
-										</span>
-									</div>
-									<div className="flex gap-2">
-										{SESSION_ORDERS.map(({ value, label }) => (
-											<button
-												type="button"
-												key={value}
-												onClick={() => setSessionOrder(value)}
-												className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
-												style={
-													sessionOrder === value
-														? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
-														: {
-																background: '#1A1A1C',
-																border: '1px solid #3A3A3C',
-																color: '#4A4A4C',
-															}
-												}
-											>
-												{label}
-											</button>
-										))}
-									</div>
-								</div>
-							</CollapsibleSection>
-
-							<CollapsibleSection label={t('settings.notifications')} defaultOpen={true}>
-								<div
-									className="flex flex-col gap-4 rounded-[20px] p-5"
-									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-								>
-									{/* Toggle row */}
-									<div className="flex items-center justify-between">
-										<div className="flex flex-col gap-0.5">
+						{/* ── SESSION tab ── */}
+						{activeTab === 'session' && (
+							<>
+								<CollapsibleSection label={t('settings.session')} defaultOpen={true}>
+									<div
+										className="flex flex-col gap-4 rounded-[20px] p-5"
+										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+									>
+										<div className="flex flex-col gap-1">
 											<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
-												{t('settings.notificationsDesc')}
+												{t('settings.prayerOrder')}
+											</span>
+											<span className="text-[11px]" style={{ color: '#6E6E70' }}>
+												{t('settings.prayerOrderDesc')}
 											</span>
 										</div>
-										<button
-											type="button"
-											role="switch"
-											aria-checked={isEnabled}
-											aria-label={t('settings.notifications')}
-											onClick={() => (isEnabled ? disable() : enable(reminderTime))}
-											className="relative h-7 w-12 rounded-full transition-colors"
-											style={{ background: isEnabled ? '#C9A962' : '#3A3A3C' }}
-										>
-											<span
-												className="absolute top-1 h-5 w-5 rounded-full transition-all"
-												style={{
-													background: '#F5F5F0',
-													left: isEnabled ? '50%' : '4px',
-												}}
-											/>
-										</button>
-									</div>
-
-									{isEnabled && permission === 'granted' && (
-										<div className="flex flex-col gap-1.5">
-											<label
-												htmlFor="input-reminder-time"
-												className="text-xs font-medium"
-												style={{ color: '#6E6E70' }}
-											>
-												{t('settings.notificationsTime')}
-											</label>
-											<input
-												id="input-reminder-time"
-												type="time"
-												value={reminderTime}
-												onChange={(e) => updateTime(e.target.value)}
-												style={inputStyle}
-											/>
+										<div className="flex gap-2">
+											{SESSION_ORDERS.map(({ value, label }) => (
+												<button
+													type="button"
+													key={value}
+													onClick={() => setSessionOrder(value)}
+													className="flex-1 rounded-[20px] py-2.5 text-[13px] font-medium transition-colors"
+													style={
+														sessionOrder === value
+															? { background: '#C9A962', color: '#1A1A1C', fontWeight: 600 }
+															: {
+																	background: '#1A1A1C',
+																	border: '1px solid #3A3A3C',
+																	color: '#4A4A4C',
+																}
+													}
+												>
+													{label}
+												</button>
+											))}
 										</div>
-									)}
+									</div>
+								</CollapsibleSection>
 
-									{permission === 'denied' && (
-										<p className="text-[11px]" style={{ color: '#D45F5F' }}>
-											{t('settings.notificationsPermissionDenied')}
-										</p>
-									)}
-								</div>
-							</CollapsibleSection>
-						</>
-					)}
-
-					{/* ── APP tab ── */}
-					{activeTab === 'app' && (
-						<>
-							{/* Données */}
-							<CollapsibleSection label={t('settings.data')} defaultOpen={true}>
-								<div
-									className="flex flex-col gap-3 rounded-[20px] p-5"
-									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-								>
-									{dataFeedback && (
-										<p
-											className="text-[11px] font-medium"
-											style={{
-												color: dataFeedback.type === 'success' ? '#6E9E6E' : '#D45F5F',
-											}}
-										>
-											{dataFeedback.message}
-										</p>
-									)}
-									<button
-										type="button"
-										onClick={handleExport}
-										className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
-										style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
+								<CollapsibleSection label={t('settings.notifications')} defaultOpen={true}>
+									<div
+										className="flex flex-col gap-4 rounded-[20px] p-5"
+										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
 									>
-										<Download size={16} style={{ color: '#C9A962' }} />
-										<span
-											className="text-xs font-semibold tracking-[1px]"
-											style={{ color: '#C9A962' }}
-										>
-											{t('settings.exportBackup')}
-										</span>
-									</button>
-
-									<input
-										ref={fileInputRef}
-										type="file"
-										accept=".json"
-										className="hidden"
-										onChange={handleFileSelect}
-									/>
-
-									<AlertDialog
-										open={pendingFile !== null}
-										onOpenChange={(open) => {
-											if (!open) setPendingFile(null);
-										}}
-									>
-										<AlertDialogTrigger asChild>
+										{/* Toggle row */}
+										<div className="flex items-center justify-between">
+											<div className="flex flex-col gap-0.5">
+												<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
+													{t('settings.notificationsDesc')}
+												</span>
+											</div>
 											<button
 												type="button"
-												onClick={() => fileInputRef.current?.click()}
-												className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
-												style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
+												role="switch"
+												aria-checked={isEnabled}
+												aria-label={t('settings.notifications')}
+												onClick={() => (isEnabled ? disable() : enable(reminderTime))}
+												className="relative h-7 w-12 rounded-full transition-colors"
+												style={{ background: isEnabled ? '#C9A962' : '#3A3A3C' }}
 											>
-												<Upload size={16} style={{ color: '#C9A962' }} />
+												<span
+													className="absolute top-1 h-5 w-5 rounded-full transition-all"
+													style={{
+														background: '#F5F5F0',
+														left: isEnabled ? '50%' : '4px',
+													}}
+												/>
+											</button>
+										</div>
+
+										{isEnabled && permission === 'granted' && (
+											<div className="flex flex-col gap-1.5">
+												<label
+													htmlFor="input-reminder-time"
+													className="text-xs font-medium"
+													style={{ color: '#6E6E70' }}
+												>
+													{t('settings.notificationsTime')}
+												</label>
+												<input
+													id="input-reminder-time"
+													type="time"
+													value={reminderTime}
+													onChange={(e) => updateTime(e.target.value)}
+													style={inputStyle}
+												/>
+											</div>
+										)}
+
+										{permission === 'denied' && (
+											<p className="text-[11px]" style={{ color: '#D45F5F' }}>
+												{t('settings.notificationsPermissionDenied')}
+											</p>
+										)}
+									</div>
+								</CollapsibleSection>
+							</>
+						)}
+
+						{/* ── APP tab ── */}
+						{activeTab === 'app' && (
+							<>
+								{/* Données */}
+								<CollapsibleSection label={t('settings.data')} defaultOpen={true}>
+									<div
+										className="flex flex-col gap-3 rounded-[20px] p-5"
+										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+									>
+										{dataFeedback && (
+											<p
+												className="text-[11px] font-medium"
+												style={{
+													color: dataFeedback.type === 'success' ? '#6E9E6E' : '#D45F5F',
+												}}
+											>
+												{dataFeedback.message}
+											</p>
+										)}
+										<button
+											type="button"
+											onClick={handleExport}
+											className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
+											style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
+										>
+											<Download size={16} style={{ color: '#C9A962' }} />
+											<span
+												className="text-xs font-semibold tracking-[1px]"
+												style={{ color: '#C9A962' }}
+											>
+												{t('settings.exportBackup')}
+											</span>
+										</button>
+
+										<input
+											ref={fileInputRef}
+											type="file"
+											accept=".json"
+											className="hidden"
+											onChange={handleFileSelect}
+										/>
+
+										<AlertDialog
+											open={pendingFile !== null}
+											onOpenChange={(open) => {
+												if (!open) setPendingFile(null);
+											}}
+										>
+											<AlertDialogTrigger asChild>
+												<button
+													type="button"
+													onClick={() => fileInputRef.current?.click()}
+													className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
+													style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
+												>
+													<Upload size={16} style={{ color: '#C9A962' }} />
+													<span
+														className="text-xs font-semibold tracking-[1px]"
+														style={{ color: '#C9A962' }}
+													>
+														{t('settings.importBackup')}
+													</span>
+												</button>
+											</AlertDialogTrigger>
+											<AlertDialogContent
+												style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+											>
+												<AlertDialogHeader>
+													<AlertDialogTitle style={{ color: '#F5F5F0' }}>
+														{t('settings.importDialogTitle')}
+													</AlertDialogTitle>
+													<AlertDialogDescription style={{ color: '#6E6E70' }}>
+														{t('settings.importDialogDesc', { filename: pendingFile?.name ?? '' })}
+													</AlertDialogDescription>
+												</AlertDialogHeader>
+												<AlertDialogFooter>
+													<AlertDialogCancel
+														style={{ background: '#2A2A2C', color: '#F5F5F0', border: 'none' }}
+													>
+														{t('settings.importDialogCancel')}
+													</AlertDialogCancel>
+													<AlertDialogAction
+														onClick={handleImportConfirm}
+														style={{ background: '#C9A962', color: '#1A1A1C' }}
+													>
+														{t('settings.importDialogConfirm')}
+													</AlertDialogAction>
+												</AlertDialogFooter>
+											</AlertDialogContent>
+										</AlertDialog>
+									</div>
+								</CollapsibleSection>
+
+								{/* Configuration */}
+								<CollapsibleSection label={t('settings.configuration')} defaultOpen={true}>
+									<div className="flex flex-col gap-3">
+										{/* Language */}
+										<div
+											className="flex gap-2 rounded-[20px] p-3"
+											style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+										>
+											{(['fr', 'en'] as const).map((lang) => (
+												<button
+													key={lang}
+													type="button"
+													onClick={() => i18n.changeLanguage(lang)}
+													className="flex-1 rounded-[16px] py-2.5 text-[13px] font-semibold transition-colors"
+													style={
+														i18n.resolvedLanguage === lang
+															? { background: '#C9A962', color: '#1A1A1C' }
+															: {
+																	background: '#1A1A1C',
+																	border: '1px solid #3A3A3C',
+																	color: '#4A4A4C',
+																}
+													}
+												>
+													{lang === 'fr' ? 'Français' : 'English'}
+												</button>
+											))}
+										</div>
+
+										{onRestartOnboarding && (
+											<button
+												type="button"
+												onClick={onRestartOnboarding}
+												className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
+												style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+											>
+												<RotateCcw size={16} style={{ color: '#C9A962' }} />
 												<span
 													className="text-xs font-semibold tracking-[1px]"
 													style={{ color: '#C9A962' }}
 												>
-													{t('settings.importBackup')}
+													{t('settings.restartOnboarding')}
+												</span>
+											</button>
+										)}
+									</div>
+								</CollapsibleSection>
+
+								{/* Version */}
+								<button
+									type="button"
+									onClick={() => setShowChangelog(true)}
+									className="flex w-full items-center justify-between rounded-[20px] px-5 py-4"
+									style={{ background: '#242426', border: '1px solid #3A3A3C' }}
+								>
+									<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
+										{t('settings.version')}
+									</span>
+									<div className="flex items-center gap-2">
+										<span className="text-sm" style={{ color: '#6E6E70' }}>
+											{__APP_VERSION__}
+										</span>
+										<ChevronRight size={14} style={{ color: '#4A4A4C' }} />
+									</div>
+								</button>
+
+								{/* Zone Danger */}
+								<CollapsibleSection label={t('settings.dangerZone')} defaultOpen={true}>
+									<AlertDialog>
+										<AlertDialogTrigger asChild>
+											<button
+												type="button"
+												className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
+												style={{ background: '#2A1515', border: '1px solid #D45F5F33' }}
+											>
+												<Trash2 size={18} style={{ color: '#D45F5F' }} />
+												<span
+													className="text-xs font-semibold tracking-[1px]"
+													style={{ color: '#D45F5F' }}
+												>
+													{t('settings.resetAll')}
 												</span>
 											</button>
 										</AlertDialogTrigger>
@@ -696,148 +815,44 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 										>
 											<AlertDialogHeader>
 												<AlertDialogTitle style={{ color: '#F5F5F0' }}>
-													{t('settings.importDialogTitle')}
+													{t('settings.resetDialogTitle')}
 												</AlertDialogTitle>
 												<AlertDialogDescription style={{ color: '#6E6E70' }}>
-													{t('settings.importDialogDesc', { filename: pendingFile?.name ?? '' })}
+													{t('settings.resetDialogDesc')}
 												</AlertDialogDescription>
 											</AlertDialogHeader>
 											<AlertDialogFooter>
 												<AlertDialogCancel
 													style={{ background: '#2A2A2C', color: '#F5F5F0', border: 'none' }}
 												>
-													{t('settings.importDialogCancel')}
+													{t('settings.resetDialogCancel')}
 												</AlertDialogCancel>
 												<AlertDialogAction
-													onClick={handleImportConfirm}
-													style={{ background: '#C9A962', color: '#1A1A1C' }}
+													onClick={async () => {
+														try {
+															await resetAll();
+															markOnboardingUndone();
+															onRestartOnboarding?.();
+														} catch {
+															setDataFeedback({
+																type: 'error',
+																message: t('settings.importError'),
+															});
+														}
+													}}
+													style={{ background: '#D45F5F', color: '#F5F5F0' }}
 												>
-													{t('settings.importDialogConfirm')}
+													{t('settings.resetDialogConfirm')}
 												</AlertDialogAction>
 											</AlertDialogFooter>
 										</AlertDialogContent>
 									</AlertDialog>
-								</div>
-							</CollapsibleSection>
-
-							{/* Configuration */}
-							<CollapsibleSection label={t('settings.configuration')} defaultOpen={true}>
-								<div className="flex flex-col gap-3">
-									{/* Language */}
-									<div
-										className="flex gap-2 rounded-[20px] p-3"
-										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-									>
-										{(['fr', 'en'] as const).map((lang) => (
-											<button
-												key={lang}
-												type="button"
-												onClick={() => i18n.changeLanguage(lang)}
-												className="flex-1 rounded-[16px] py-2.5 text-[13px] font-semibold transition-colors"
-												style={
-													i18n.resolvedLanguage === lang
-														? { background: '#C9A962', color: '#1A1A1C' }
-														: {
-																background: '#1A1A1C',
-																border: '1px solid #3A3A3C',
-																color: '#4A4A4C',
-															}
-												}
-											>
-												{lang === 'fr' ? 'Français' : 'English'}
-											</button>
-										))}
-									</div>
-
-									{onRestartOnboarding && (
-										<button
-											type="button"
-											onClick={onRestartOnboarding}
-											className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
-											style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-										>
-											<RotateCcw size={16} style={{ color: '#C9A962' }} />
-											<span
-												className="text-xs font-semibold tracking-[1px]"
-												style={{ color: '#C9A962' }}
-											>
-												{t('settings.restartOnboarding')}
-											</span>
-										</button>
-									)}
-								</div>
-							</CollapsibleSection>
-
-							{/* Version */}
-							<div
-								className="flex items-center justify-between rounded-[20px] px-5 py-4"
-								style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-							>
-								<span className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
-									{t('settings.version')}
-								</span>
-								<span className="text-sm" style={{ color: '#6E6E70' }}>
-									{__APP_VERSION__}
-								</span>
-							</div>
-
-							{/* Zone Danger */}
-							<CollapsibleSection label={t('settings.dangerZone')} defaultOpen={true}>
-								<AlertDialog>
-									<AlertDialogTrigger asChild>
-										<button
-											type="button"
-											className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4"
-											style={{ background: '#2A1515', border: '1px solid #D45F5F33' }}
-										>
-											<Trash2 size={18} style={{ color: '#D45F5F' }} />
-											<span
-												className="text-xs font-semibold tracking-[1px]"
-												style={{ color: '#D45F5F' }}
-											>
-												{t('settings.resetAll')}
-											</span>
-										</button>
-									</AlertDialogTrigger>
-									<AlertDialogContent
-										style={{ background: '#242426', border: '1px solid #3A3A3C' }}
-									>
-										<AlertDialogHeader>
-											<AlertDialogTitle style={{ color: '#F5F5F0' }}>
-												{t('settings.resetDialogTitle')}
-											</AlertDialogTitle>
-											<AlertDialogDescription style={{ color: '#6E6E70' }}>
-												{t('settings.resetDialogDesc')}
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel
-												style={{ background: '#2A2A2C', color: '#F5F5F0', border: 'none' }}
-											>
-												{t('settings.resetDialogCancel')}
-											</AlertDialogCancel>
-											<AlertDialogAction
-												onClick={async () => {
-													try {
-														await resetAll();
-														markOnboardingUndone();
-														onRestartOnboarding?.();
-													} catch {
-														setDataFeedback({ type: 'error', message: t('settings.importError') });
-													}
-												}}
-												style={{ background: '#D45F5F', color: '#F5F5F0' }}
-											>
-												{t('settings.resetDialogConfirm')}
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
-							</CollapsibleSection>
-						</>
-					)}
-				</motion.div>
-			</AnimatePresence>
-		</div>
+								</CollapsibleSection>
+							</>
+						)}
+					</motion.div>
+				</AnimatePresence>
+			</div>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary

- Adds a full-screen slide-in `Changelog` component with spring animation (slides in from right)
- Tapping the version row in Settings → App tab opens the changelog
- Version row gets a `ChevronRight` icon to signal interactivity
- Lists all releases from v1.0.0 to v1.0.18 with date and bullet points
- Bilingual: French and English (based on app language setting)
- Back button closes the overlay

## Test plan

- [ ] Open Settings → App tab → tap the version row → changelog slides in
- [ ] Back button returns to settings
- [ ] Entries display correctly in French and English
- [ ] Animation is smooth on mobile