### PR TITLE
feat(sensor): camera brightness sujood detection (phone-call style)

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.0.19',
+		date: '2026-03-21',
+		changes: {
+			fr: [
+				'Détecteur de sujoud basé sur la luminosité de la caméra frontale (style appel téléphonique)',
+				'Basculement automatique vers gyroscope ou bouton manuel si caméra indisponible',
+			],
+			en: [
+				'Sujood detector using front camera brightness (phone-call style)',
+				'Automatic fallback to gyroscope or manual button when camera unavailable',
+			],
+		},
+	},
+	{
 		version: '1.0.18',
 		date: '2026-03-20',
 		changes: {

--- a/src/hooks/useProximitySensor.test.ts
+++ b/src/hooks/useProximitySensor.test.ts
@@ -275,4 +275,197 @@ describe('useProximitySensor', () => {
 			expect(onFirst).toHaveBeenCalledOnce();
 		});
 	});
+
+	describe('supported via camera brightness', () => {
+		const PIXEL_COUNT = 80 * 60;
+		let pixelData: Uint8ClampedArray;
+		let mockGetUserMedia: ReturnType<typeof vi.fn>;
+		let mockStop: ReturnType<typeof vi.fn>;
+		let mockCtx: { drawImage: ReturnType<typeof vi.fn>; getImageData: ReturnType<typeof vi.fn> };
+		let mockVideo: { muted: boolean; srcObject: unknown; play: ReturnType<typeof vi.fn> };
+
+		beforeEach(() => {
+			pixelData = new Uint8ClampedArray(PIXEL_COUNT * 4).fill(200);
+			mockStop = vi.fn();
+			mockCtx = {
+				drawImage: vi.fn(),
+				getImageData: vi.fn().mockImplementation(() => ({ data: pixelData })),
+			};
+			mockVideo = { muted: false, srcObject: null, play: vi.fn().mockResolvedValue(undefined) };
+			mockGetUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [{ stop: mockStop }] });
+
+			Object.defineProperty(navigator, 'mediaDevices', {
+				value: { getUserMedia: mockGetUserMedia },
+				configurable: true,
+				writable: true,
+			});
+
+			const originalCreateElement = document.createElement.bind(document);
+			vi.spyOn(document, 'createElement').mockImplementation((tag: string, options?: unknown) => {
+				if (tag === 'canvas') return { getContext: () => mockCtx, width: 0, height: 0 } as any;
+				if (tag === 'video') return mockVideo as any;
+				return originalCreateElement(tag, options as ElementCreationOptions | undefined);
+			});
+
+			delete (window as any).DeviceOrientationEvent;
+			vi.useFakeTimers({
+				toFake: ['Date', 'setInterval', 'clearInterval', 'setTimeout', 'clearTimeout'],
+				now: PINNED_NOW,
+			});
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			vi.restoreAllMocks();
+			Object.defineProperty(navigator, 'mediaDevices', {
+				value: undefined,
+				configurable: true,
+				writable: true,
+			});
+			delete (window as any).DeviceOrientationEvent;
+		});
+
+		it('returns isSupported: true when getUserMedia available', () => {
+			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+			expect(result.current.isSupported).toBe(true);
+		});
+
+		it('starts in waiting_first when active', () => {
+			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+			expect(result.current.currentState).toBe('waiting_first');
+		});
+
+		it('detects sujood: covered ≥ 300ms then uncovered fires onFirstSujood', async () => {
+			const onFirst = vi.fn();
+			const { result } = renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			pixelData.fill(0);
+			act(() => vi.advanceTimersByTime(200)); // tick 1 at +200ms: dark → coveredSinceMs = PINNED_NOW+200
+			act(() => vi.advanceTimersByTime(200)); // tick 2 at +400ms: dark
+			pixelData.fill(200);
+			act(() => vi.advanceTimersByTime(200)); // tick 3 at +600ms: bright, elapsed=400ms → fires
+
+			expect(onFirst).toHaveBeenCalledOnce();
+			expect(result.current.currentState).toBe('waiting_second');
+		});
+
+		it('does not fire if uncovered too fast (< 300ms)', async () => {
+			const onFirst = vi.fn();
+			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			pixelData.fill(0);
+			act(() => vi.advanceTimersByTime(200)); // tick 1: dark → coveredSinceMs set
+			pixelData.fill(200);
+			act(() => vi.advanceTimersByTime(200)); // tick 2: bright, elapsed=200ms < 300ms → no callback
+
+			expect(onFirst).not.toHaveBeenCalled();
+		});
+
+		it('does not fire if covered too long (> 5000ms)', async () => {
+			const onFirst = vi.fn();
+			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			pixelData.fill(0);
+			act(() => vi.advanceTimersByTime(200)); // dark → coveredSinceMs set at PINNED_NOW+200
+			act(() => vi.advanceTimersByTime(5200)); // advance 5200ms (elapsed > 5000ms max)
+			pixelData.fill(200);
+			act(() => vi.advanceTimersByTime(200)); // bright, but elapsed > 5000ms → no callback
+
+			expect(onFirst).not.toHaveBeenCalled();
+		});
+
+		it("detects two sujoods in sequence completing a rak'a", async () => {
+			const onFirst = vi.fn();
+			const onSecond = vi.fn();
+			const { result } = renderHook(() => useProximitySensor(true, onFirst, onSecond));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			pixelData.fill(0);
+			act(() => vi.advanceTimersByTime(200)); // dark
+			act(() => vi.advanceTimersByTime(200)); // dark
+			pixelData.fill(200);
+			act(() => vi.advanceTimersByTime(200)); // bright, elapsed=400ms → onFirst
+
+			expect(onFirst).toHaveBeenCalledOnce();
+
+			act(() => vi.advanceTimersByTime(800)); // advance past 800ms debounce
+
+			pixelData.fill(0);
+			act(() => vi.advanceTimersByTime(200)); // dark
+			act(() => vi.advanceTimersByTime(200)); // dark
+			pixelData.fill(200);
+			act(() => vi.advanceTimersByTime(200)); // bright, elapsed=400ms → onSecond
+
+			expect(onSecond).toHaveBeenCalledOnce();
+			expect(result.current.currentState).toBe('waiting_first');
+		});
+
+		it('calls stream track stop on unmount', async () => {
+			const { unmount } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			unmount();
+
+			expect(mockStop).toHaveBeenCalled();
+		});
+
+		it('falls back to DeviceOrientationEvent when permission denied', async () => {
+			mockGetUserMedia.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'));
+			(window as any).DeviceOrientationEvent = class {};
+			const addSpy = vi.spyOn(window, 'addEventListener');
+
+			renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			expect(addSpy).toHaveBeenCalledWith('deviceorientation', expect.any(Function));
+		});
+
+		it('falls back to unsupported when camera denied and no orientation', async () => {
+			mockGetUserMedia.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'));
+
+			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			act(() => vi.advanceTimersByTime(3000));
+
+			expect(result.current.isSupported).toBe(false);
+			expect(result.current.currentState).toBe('unsupported');
+		});
+
+		it('stops stream if resolved after component unmounts', async () => {
+			const { unmount } = renderHook(() => useProximitySensor(true, vi.fn(), vi.fn()));
+
+			unmount();
+
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			expect(mockStop).toHaveBeenCalled();
+		});
+	});
 });

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -14,6 +14,11 @@ const MIN_SUJOOD_DURATION_MS = 300;
 const MAX_SUJOOD_DURATION_MS = 5000;
 const DEBOUNCE_MS = 800;
 const ORIENTATION_STARTUP_TIMEOUT_MS = 3000;
+const CAMERA_WIDTH = 80;
+const CAMERA_HEIGHT = 60;
+const CAMERA_INTERVAL_MS = 200;
+const CAMERA_DARK_THRESHOLD = 25;
+const CAMERA_LIGHT_THRESHOLD = 50;
 
 export function useProximitySensor(
 	active: boolean,
@@ -37,7 +42,9 @@ export function useProximitySensor(
 		const hasProximitySensor = typeof (window as any).ProximitySensor !== 'undefined';
 		const hasDeviceProximity = typeof (window as any).ondeviceproximity !== 'undefined';
 		const hasDeviceOrientation = typeof window.DeviceOrientationEvent !== 'undefined';
-		const hasSupport = hasProximitySensor || hasDeviceProximity || hasDeviceOrientation;
+		const hasCamera = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
+		const hasSupport =
+			hasProximitySensor || hasDeviceProximity || hasCamera || hasDeviceOrientation;
 
 		setIsSupported(hasSupport);
 
@@ -186,6 +193,93 @@ export function useProximitySensor(
 		if (typeof (window as any).ondeviceproximity !== 'undefined') {
 			setupDeviceProximityFallback();
 			return setupCleanup();
+		}
+
+		if (hasCamera) {
+			let orientationTimerCleanup: (() => void) | undefined;
+
+			const setupCameraFallback = async () => {
+				try {
+					const stream = await navigator.mediaDevices.getUserMedia({
+						video: { facingMode: 'user', width: CAMERA_WIDTH, height: CAMERA_HEIGHT },
+					});
+					if (cancelled) {
+						for (const t of stream.getTracks()) t.stop();
+						return;
+					}
+					const video = document.createElement('video');
+					video.muted = true;
+					video.srcObject = stream;
+					void video.play().catch(() => {});
+					const canvas = document.createElement('canvas');
+					canvas.width = CAMERA_WIDTH;
+					canvas.height = CAMERA_HEIGHT;
+					const ctx = canvas.getContext('2d');
+					if (!ctx) {
+						for (const t of stream.getTracks()) t.stop();
+						if (!cancelled) {
+							orientationTimerCleanup = setupDeviceOrientationFallback();
+						}
+						return;
+					}
+					let coveredSinceMs = 0;
+					const intervalId = setInterval(() => {
+						if (cancelled) {
+							clearInterval(intervalId);
+							return;
+						}
+						try {
+							ctx.drawImage(video, 0, 0, CAMERA_WIDTH, CAMERA_HEIGHT);
+							const { data } = ctx.getImageData(0, 0, CAMERA_WIDTH, CAMERA_HEIGHT);
+							let sum = 0;
+							for (let i = 0; i < data.length; i += 4) {
+								sum += (data[i] + data[i + 1] + data[i + 2]) / 3;
+							}
+							const avg = sum / (CAMERA_WIDTH * CAMERA_HEIGHT);
+							if (coveredSinceMs === 0 && avg < CAMERA_DARK_THRESHOLD) {
+								coveredSinceMs = Date.now();
+							} else if (coveredSinceMs > 0 && avg > CAMERA_LIGHT_THRESHOLD) {
+								const elapsed = Date.now() - coveredSinceMs;
+								coveredSinceMs = 0;
+								if (elapsed >= MIN_SUJOOD_DURATION_MS && elapsed <= MAX_SUJOOD_DURATION_MS) {
+									handleProximityDetection(true);
+								}
+							}
+						} catch {}
+					}, CAMERA_INTERVAL_MS);
+					sensorRef.current = {
+						stop: () => {
+							clearInterval(intervalId);
+							for (const t of stream.getTracks()) t.stop();
+							video.srcObject = null;
+						},
+					};
+				} catch {
+					if (!cancelled) {
+						orientationTimerCleanup = setupDeviceOrientationFallback();
+					}
+				}
+			};
+
+			setupCameraFallback();
+
+			return () => {
+				cancelled = true;
+				orientationTimerCleanup?.();
+				if (sensorRef.current) {
+					try {
+						if (typeof sensorRef.current.stop === 'function') {
+							sensorRef.current.stop();
+						} else if (typeof sensorRef.current === 'function') {
+							window.removeEventListener('deviceorientation', sensorRef.current);
+						}
+					} catch {}
+					sensorRef.current = null;
+				}
+				betaBaselineRef.current = null;
+				sujoodDownTimeRef.current = 0;
+				setCurrentState('idle');
+			};
 		}
 
 		const timerCleanup = setupDeviceOrientationFallback();


### PR DESCRIPTION
## Summary

- Replaces DeviceOrientationEvent (tilt-based) fallback with front-camera brightness detection
- Phone lies screen-up on floor → user prostrates → body covers camera → brightness drops → on lifting → sujood counted
- Fallback chain: `ProximitySensor` → `deviceproximity` → **camera** → `DeviceOrientationEvent` → manual button
- Camera parameters: 80×60 resolution, 5fps, dark threshold 25/255, light threshold 50/255 (hysteresis), min 300ms hold
- Permission denied gracefully falls through to orientation fallback, then manual

## Test plan

- [ ] Run `pnpm test:run` → 141/141 tests pass
- [ ] On Android Chrome: start session, hold phone flat, prostrate (cover camera with body), lift → 1st sujood counted
- [ ] Repeat → 2nd sujood → rak'a logged
- [ ] Deny camera permission → session still works (orientation/gyroscope fallback)
- [ ] Open on desktop → manual button shown (camera denied + orientation null)
- [ ] After session ends → camera LED off (stream tracks stopped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proximity detection with a camera-based fallback method. The app now supports proximity interaction detection on a broader range of devices lacking standard proximity sensors, improving device compatibility.

* **Documentation**
  * Updated changelog for version 1.0.19.

* **Tests**
  * Added comprehensive test coverage for proximity detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->