### PR TITLE
feat(session): track rak'at within prayer before logging completion

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -544,7 +544,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 									} else if (!busyRef.current) {
 										navigator.vibrate?.([50, 50, 150]);
 										setSujoodCount(0);
-										handleAutoIncrement();
+										handleRakatComplete();
 									}
 								}}
 								className="w-full mb-6 py-5 rounded-2xl text-center font-semibold tracking-[1px]"
@@ -568,6 +568,18 @@ export function Session({ onClose }: { onClose: () => void }) {
 							>
 								{sujoodCount === 0 ? t('session.manualSujood1') : t('session.manualSujood2')}
 							</motion.button>
+						)}
+
+						{cfg.rakat > 1 && (
+							<motion.div
+								className="w-full mb-4 text-center text-xs font-medium tracking-[2px]"
+								style={{ color: '#4A4A4C' }}
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								transition={{ delay: 0.12 }}
+							>
+								{t('session.rakatProgress', { current: currentRakat + 1, total: cfg.rakat })}
+							</motion.div>
 						)}
 
 						<AnimatePresence mode="wait">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,6 +78,7 @@
 		"start": "START",
 		"cancel": "Cancel",
 		"progress": "PROGRESS",
+		"rakatProgress": "Rak'a {{current}} / {{total}}",
 		"sujood1": "✋ Waiting for 1st sujood",
 		"sujood2": "✋ Waiting for 2nd sujood",
 		"manualSujood1": "1st sujood",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -78,6 +78,7 @@
 		"start": "DÉMARRER",
 		"cancel": "Annuler",
 		"progress": "PROGRESSION",
+		"rakatProgress": "Rak'a {{current}} / {{total}}",
 		"sujood1": "✋ Attente du 1er sujood",
 		"sujood2": "✋ Attente du 2ème sujood",
 		"manualSujood1": "1er sujoud",


### PR DESCRIPTION
## Summary

- Two sujoods now correctly count as one rak'a instead of one full prayer
- A prayer (e.g. Asr = 4 rak'ats) is only logged after all required rak'ats are completed (8 sujoods total)
- Adds rak'at progress indicator in session UI (e.g. "Rak'a 1 / 4")
- Both automatic sensor detection and manual button now use the same rak'at-aware logic
- Adds `session.rakatProgress` i18n key in French and English

## Test plan

- [ ] Start a session and verify Asr requires 8 sujoods (4 rak'ats) before being logged
- [ ] Verify Fajr requires 4 sujoods (2 rak'ats)
- [ ] Verify rak'at progress indicator shows correct current/total
- [ ] Verify manual button follows same rak'at tracking logic
- [ ] Run `pnpm test:run` — all 141 tests pass