### PR TITLE
feat(dashboard): add motion design to main page

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -206,30 +206,33 @@ export function Dashboard() {
 					/>
 				</div>
 
-				{stats.estimatedDays !== null && (
-					<motion.div
-						initial={{ opacity: 0, y: 8 }}
-						animate={{ opacity: 1, y: 0 }}
-						exit={{ opacity: 0, y: 8 }}
-						transition={{ delay: 0.22, ...spring }}
-						className="flex items-center justify-between rounded-[20px] px-6"
-						style={{
-							background: 'linear-gradient(135deg, #1E1A12 0%, #242426 70%)',
-							border: '1px solid rgba(201, 169, 98, 0.3)',
-							minHeight: 88,
-						}}
-					>
-						<span className="text-[13px] font-medium" style={{ color: '#9A9A9C' }}>
-							{t('stats.estimation')}
-						</span>
-						<span
-							className="max-w-[60%] text-right text-2xl font-semibold tabular-nums leading-snug"
-							style={{ color: '#C9A962' }}
+				<AnimatePresence>
+					{stats.estimatedDays !== null && (
+						<motion.div
+							key="estimation"
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							exit={{ opacity: 0, y: 8 }}
+							transition={{ delay: 0.22, ...spring }}
+							className="flex items-center justify-between rounded-[20px] px-6"
+							style={{
+								background: 'linear-gradient(135deg, #1E1A12 0%, #242426 70%)',
+								border: '1px solid rgba(201, 169, 98, 0.3)',
+								minHeight: 88,
+							}}
 						>
-							{formatDays(stats.estimatedDays, t)}
-						</span>
-					</motion.div>
-				)}
+							<span className="text-[13px] font-medium" style={{ color: '#9A9A9C' }}>
+								{t('stats.estimation')}
+							</span>
+							<span
+								className="max-w-[60%] text-right text-2xl font-semibold tabular-nums leading-snug"
+								style={{ color: '#C9A962' }}
+							>
+								{formatDays(stats.estimatedDays, t)}
+							</span>
+						</motion.div>
+					)}
+				</AnimatePresence>
 
 				<div className="flex flex-col gap-2.5">
 					<motion.p


### PR DESCRIPTION
## Summary

- Staggered entrance animations coordinated across all dashboard sections
- Shimmer sweep effect on the gold "total remaining" card (repeating, 3s pause)
- `StatPill` entrance with scale+fade and `whileHover` scale
- `PrayerRow` stagger with slide from left (`x: -16 → 0`)
- Progress bars animated via `motion.div` with spring easing (matching Session.tsx pattern)
- Session launcher and `+` buttons converted to `motion.button` with `whileTap`/`whileHover`
- All animations use the same spring system as `Session.tsx` (`stiffness: 400, damping: 30`)

## Test plan

- [ ] Open dashboard — verify staggered entrance from top to bottom
- [ ] Verify shimmer sweeps across the gold card every ~5s
- [ ] Verify `StatPill` hover scales up slightly
- [ ] Verify prayer rows slide in from left with stagger delay
- [ ] Verify progress bars animate in on load
- [ ] Verify `+` button scales down on tap
- [ ] Verify session launcher has tap/hover feedback
- [ ] Run `pnpm run build` — no type errors

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added coordinated entry and staggered animations across the dashboard for smoother load and improved hierarchy
  * Animated stat and prayer list items with delayed reveal and interactive hover/tap feedback
  * Enhanced CTA and header with entrance and micro-interactions for a livelier UI
  * Added animated shimmer and smoother transitions for estimated-day updates and section labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->