### PR TITLE
chore(ci): auto-detect bump type from conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,21 +43,17 @@ jobs:
             echo "type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           else
             LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -z "$LAST_TAG" ]; then
-              COMMITS=$(git log --format="%s%n%b" HEAD)
-            else
-              COMMITS=$(git log --format="%s%n%b" "${LAST_TAG}..HEAD")
-            fi
-
+            RANGE="${LAST_TAG:+${LAST_TAG}..}HEAD"
             BUMP="patch"
 
-            if echo "$COMMITS" | grep -qE "BREAKING CHANGE |^(feat|fix|refactor|perf|chore)!(\(.+\))?:"; then
+            if git log --format="%s" "$RANGE" | grep -qE "^[a-z]+(\(.+\))?!:" || \
+               git log --format="%b" "$RANGE" | grep -qE "^BREAKING[ -]CHANGE[: ]"; then
               BUMP="major"
-            elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+            elif git log --format="%s" "$RANGE" | grep -qE "^feat(\(.+\))?:"; then
               BUMP="minor"
             fi
 
-            echo "type=$BUMP" >> $GITHUB_OUTPUT
+            echo "type=$BUMP" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

• Replace hardcoded `patch` bump with commit analysis since last git tag
• `BREAKING CHANGE` or `feat!:`/`fix!:` → **major**
• `feat:` or `feat(scope):` → **minor**
• All other commits → **patch**
• `workflow_dispatch` manual override preserved and takes priority

## Type

chore

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release versioning to automatically determine semantic version bumps (major, minor, or patch) based on commit history instead of always defaulting to patch versions. Breaking changes now trigger major releases, new features trigger minor releases, and other updates trigger patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->