### PR TITLE
fix(ci): sanitize bump type output before shell interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
         id: bump
         env:
           BUMP_TYPE: ${{ github.event.inputs.bump || 'patch' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BUMP="$BUMP_TYPE"
           else
             LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

• Unify output into a single write point at end of "Determine bump type" step
• Add validation guard: `[[ "$BUMP" =~ ^(patch|minor|major)$ ]] || exit 1`
• Pass bump type to "Bump version" via `env: BUMP:` instead of inline expression
• Prevents shell injection if step output is ever tampered via API-triggered dispatch

## Type

fix

Closes #84