### PR TITLE
feat(ui): add directional slide animation when switching tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ export function App() {
 	const directionRef = useRef(0);
 
 	function handleTabChange(tab: Tab) {
+		if (tab === activeTab) return;
 		directionRef.current = TAB_ORDER.indexOf(tab) > TAB_ORDER.indexOf(activeTab) ? 1 : -1;
 		setActiveTab(tab);
 	}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -26,6 +26,16 @@ import { PRAYER_NAMES } from '@/types';
 type Tab = 'debt' | 'session' | 'app';
 type DebtMode = 'years' | 'manual';
 
+const SETTINGS_TAB_ORDER: Tab[] = ['debt', 'session', 'app'];
+
+const settingsSlideVariants = {
+	initial: (dir: number) => ({ x: dir * 100 + '%', opacity: 0 }),
+	animate: { x: 0, opacity: 1 },
+	exit: (dir: number) => ({ x: dir * -100 + '%', opacity: 0 }),
+};
+
+const settingsSlideTransition = { duration: 0.22, ease: [0.32, 0.72, 0, 1] as const };
+
 function CollapsibleSection({
 	label,
 	defaultOpen,
@@ -100,12 +110,12 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 	const debts = useDebts();
 
 	const [activeTab, setActiveTab] = useState<Tab>('debt');
-	const settingsTabOrder: Tab[] = ['debt', 'session', 'app'];
 	const settingsDirRef = useRef(0);
 
 	function handleSettingsTabChange(tab: Tab) {
+		if (tab === activeTab) return;
 		settingsDirRef.current =
-			settingsTabOrder.indexOf(tab) > settingsTabOrder.indexOf(activeTab) ? 1 : -1;
+			SETTINGS_TAB_ORDER.indexOf(tab) > SETTINGS_TAB_ORDER.indexOf(activeTab) ? 1 : -1;
 		setActiveTab(tab);
 	}
 	const [debtMode, setDebtMode] = useState<DebtMode>('years');
@@ -262,15 +272,11 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 					<motion.div
 						key={activeTab}
 						custom={settingsDirRef.current}
-						variants={{
-							initial: (dir: number) => ({ x: dir * 100 + '%', opacity: 0 }),
-							animate: { x: 0, opacity: 1 },
-							exit: (dir: number) => ({ x: dir * -100 + '%', opacity: 0 }),
-						}}
+						variants={settingsSlideVariants}
 						initial="initial"
 						animate="animate"
 						exit="exit"
-						transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+						transition={settingsSlideTransition}
 						className="flex flex-col gap-5 overflow-hidden"
 					>
 						{/* ── DETTE tab ── */}


### PR DESCRIPTION
## Summary

• Wraps main page content in `AnimatePresence + motion.div` with directional slide variants — tapping a tab to the right slides left, tapping left slides right
• Uses a `directionRef` to compute direction from tab index comparison without triggering extra re-renders
• Settings internal tabs (Debt / Session / App) use the same slide pattern, replacing the previous y-fade
• Slide duration 220ms with `ease: [0.32, 0.72, 0, 1]` for a snappy iOS-like feel

## Type

feat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Implemented smooth animated transitions when switching tabs throughout the application
  * Tab changes now feature directional slide animations in both main navigation and settings
  * Settings navigation provides visual feedback with contextual movement based on tab direction
  * Pages gracefully transition before new content enters for improved visual flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->