### PR TITLE
fix(app): prevent entrance animation replay on tab revisit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,8 +26,10 @@ export function App() {
 		if (param === 'log' || param === 'stats' || param === 'settings') return param as Tab;
 		return 'dashboard';
 	});
+	const [mountedTabs, setMountedTabs] = useState<Set<Tab>>(() => new Set([activeTab]));
 	function handleTabChange(tab: Tab) {
 		if (tab === activeTab) return;
+		setMountedTabs((prev) => new Set([...prev, tab]));
 		setActiveTab(tab);
 	}
 	const [showOnboarding, setShowOnboarding] = useState(!isOnboardingDone());
@@ -119,11 +121,14 @@ export function App() {
 	return (
 		<div className="min-h-dvh" style={{ background: '#1A1A1C' }}>
 			<main className="mx-auto max-w-lg pt-4 pb-28 overflow-hidden">
-				{(Object.keys(pages) as Tab[]).map((tab) => (
-					<div key={tab} hidden={tab !== activeTab}>
-						{pages[tab]}
-					</div>
-				))}
+				{(Object.keys(pages) as Tab[]).map(
+					(tab) =>
+						mountedTabs.has(tab) && (
+							<div key={tab} hidden={tab !== activeTab}>
+								{pages[tab]}
+							</div>
+						),
+				)}
 			</main>
 			<AnimatePresence>
 				{!showOnboarding && installPrompt && shouldShowInstallBanner() && (

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -14,10 +14,10 @@ const ENTRIES: ChangelogEntry[] = [
 		date: '2026-03-26',
 		changes: {
 			fr: [
-				"Navigation : les onglets restent montés en mémoire — plus d'animations répétitives en revenant sur le Dashboard",
+				"Navigation : montage différé des onglets — monté au premier accès, gardé en mémoire ensuite (plus d'animations répétitives, plus d'écouteurs fantômes)",
 			],
 			en: [
-				'Navigation: tabs stay mounted — no more repeated entrance animations when returning to Dashboard',
+				'Navigation: lazy-mount tabs — mounted on first visit, kept alive after (no more repeated animations, no stale background listeners)',
 			],
 		},
 	},


### PR DESCRIPTION
## Summary

- All tab pages are now kept mounted using the `hidden` HTML attribute instead of being unmounted/remounted on each tab switch
- Removes the `AnimatePresence`/`motion.div` slide wrapper (and the now-unused `slideVariants`, `slideTransition`, `directionRef`, `TAB_ORDER` constants)
- `AnimatePresence` is retained for the install banner
- First visit to any tab still shows the page's entrance animations; returning to a tab replays nothing

Closes #76

## Test plan

- [ ] `pnpm run build` passes with no TypeScript errors
- [ ] `pnpm run lint` reports no errors
- [ ] Switching to a tab for the first time shows entrance animations normally
- [ ] Switching back to a previously visited tab shows no entrance animations
- [ ] All 4 tabs render their content correctly
- [ ] Install banner still animates in/out correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tab navigation transitions simplified; animated effects removed for streamlined switching

* **Documentation**
  * Version 1.12.0 changelog entry added documenting navigation behavior updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->