### PR TITLE
refactor(stats): wire PeriodSelector, usePersistedPeriod, useOutsideClick into chart components

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,18 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.14.0',
+		date: '2026-03-26',
+		changes: {
+			fr: [
+				'Stats : DebtEvolutionChart et StatsChart utilisent désormais les hooks et composants partagés (PeriodSelector, usePersistedPeriod, useOutsideClick)',
+			],
+			en: [
+				'Stats: DebtEvolutionChart and StatsChart now use shared hooks and component (PeriodSelector, usePersistedPeriod, useOutsideClick)',
+			],
+		},
+	},
+	{
 		version: '1.13.0',
 		date: '2026-03-26',
 		changes: {

--- a/src/components/DebtEvolutionChart.tsx
+++ b/src/components/DebtEvolutionChart.tsx
@@ -1,8 +1,11 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PeriodSelector } from '@/components/PeriodSelector';
 import { db } from '@/db/database';
 import { getDebtEvolution } from '@/db/queries';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
+import { usePersistedPeriod } from '@/hooks/usePersistedPeriod';
 
 const PERIODS = [
 	{ label: '7j', days: 7 },
@@ -17,17 +20,13 @@ const spring = { type: 'spring' as const, stiffness: 400, damping: 30 };
 
 export function DebtEvolutionChart() {
 	const { t } = useTranslation();
-	const [days, setDays] = useState(() => {
-		const stored = Number(localStorage.getItem(CHART_PERIOD_KEY));
-		return PERIODS.some((p) => p.days === stored) ? stored : 30;
-	});
+	const [days, setDays] = usePersistedPeriod(CHART_PERIOD_KEY, PERIODS);
 	const [data, setData] = useState<{ date: string; remaining: number }[]>([]);
 	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 	const chartRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		let ignore = false;
-		localStorage.setItem(CHART_PERIOD_KEY, String(days));
 		setHoveredIndex(null);
 		getDebtEvolution(db, days).then((result) => {
 			if (!ignore) setData(result);
@@ -37,15 +36,7 @@ export function DebtEvolutionChart() {
 		};
 	}, [days]);
 
-	useEffect(() => {
-		function handleClick(e: PointerEvent) {
-			if (chartRef.current && !chartRef.current.contains(e.target as Node)) {
-				setHoveredIndex(null);
-			}
-		}
-		document.addEventListener('pointerdown', handleClick);
-		return () => document.removeEventListener('pointerdown', handleClick);
-	}, []);
+	useOutsideClick(chartRef, () => setHoveredIndex(null));
 
 	const hasData = data.length > 0 && data.some((d) => d.remaining > 0);
 	const minRemaining = hasData ? Math.min(...data.map((d) => d.remaining)) : 0;
@@ -91,29 +82,7 @@ export function DebtEvolutionChart() {
 
 	return (
 		<div className="flex flex-col gap-3">
-			<div className="flex gap-1.5 overflow-x-auto pb-0.5 scrollbar-none">
-				{PERIODS.map((p) => {
-					const active = p.days === days;
-					return (
-						<motion.button
-							key={p.days}
-							type="button"
-							onClick={() => setDays(p.days)}
-							className="shrink-0 rounded-xl px-3 py-1.5 text-[11px] font-semibold tracking-wide"
-							style={
-								active
-									? { background: '#C9A962', color: '#1A1A1C' }
-									: { background: '#1A1A1C', color: '#6E6E70' }
-							}
-							whileTap={{ scale: 0.88 }}
-							animate={active ? { scale: 1.04 } : { scale: 1 }}
-							transition={spring}
-						>
-							{p.label}
-						</motion.button>
-					);
-				})}
-			</div>
+			<PeriodSelector periods={PERIODS} activeDays={days} onSelect={setDays} />
 
 			{hasData && currentValue !== null && (
 				<div className="flex gap-2">

--- a/src/components/StatsChart.tsx
+++ b/src/components/StatsChart.tsx
@@ -1,8 +1,11 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PeriodSelector } from '@/components/PeriodSelector';
 import { db } from '@/db/database';
 import { getLogsByPeriod } from '@/db/queries';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
+import { usePersistedPeriod } from '@/hooks/usePersistedPeriod';
 import { aggregateDaily, aggregateWeekly, formatTooltipDate } from '@/lib/chartUtils';
 
 const PERIODS = [
@@ -20,17 +23,13 @@ const spring = { type: 'spring' as const, stiffness: 400, damping: 30 };
 
 export function StatsChart() {
 	const { t, i18n } = useTranslation();
-	const [days, setDays] = useState(() => {
-		const stored = Number(localStorage.getItem(CHART_PERIOD_KEY));
-		return PERIODS.some((p) => p.days === stored) ? stored : 30;
-	});
+	const [days, setDays] = usePersistedPeriod(CHART_PERIOD_KEY, PERIODS);
 	const [data, setData] = useState<{ date: string; count: number }[]>([]);
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 	const chartRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		let ignore = false;
-		localStorage.setItem(CHART_PERIOD_KEY, String(days));
 		setSelectedIndex(null);
 		getLogsByPeriod(db, days).then((result) => {
 			if (!ignore) setData(result);
@@ -40,15 +39,7 @@ export function StatsChart() {
 		};
 	}, [days]);
 
-	useEffect(() => {
-		function handleClick(e: PointerEvent) {
-			if (chartRef.current && !chartRef.current.contains(e.target as Node)) {
-				setSelectedIndex(null);
-			}
-		}
-		document.addEventListener('pointerdown', handleClick);
-		return () => document.removeEventListener('pointerdown', handleClick);
-	}, []);
+	useOutsideClick(chartRef, () => setSelectedIndex(null));
 
 	const weekly = days > 30;
 	const bars = weekly ? aggregateWeekly(data) : aggregateDaily(data);
@@ -60,34 +51,9 @@ export function StatsChart() {
 			className="flex flex-col gap-3 rounded-[20px] px-4 py-4"
 			style={{ background: '#242426', border: '1px solid #3A3A3C' }}
 		>
-			{/* Period selector */}
-			<div className="flex gap-1.5 overflow-x-auto pb-0.5 scrollbar-none">
-				{PERIODS.map((p) => {
-					const active = p.days === days;
-					return (
-						<motion.button
-							key={p.days}
-							type="button"
-							onClick={() => setDays(p.days)}
-							className="shrink-0 rounded-xl px-3 py-1.5 text-[11px] font-semibold tracking-wide"
-							style={
-								active
-									? { background: '#C9A962', color: '#1A1A1C' }
-									: { background: '#1A1A1C', color: '#6E6E70' }
-							}
-							whileTap={{ scale: 0.88 }}
-							animate={active ? { scale: 1.04 } : { scale: 1 }}
-							transition={spring}
-						>
-							{p.label}
-						</motion.button>
-					);
-				})}
-			</div>
+			<PeriodSelector periods={PERIODS} activeDays={days} onSelect={setDays} />
 
-			{/* Chart */}
 			<div ref={chartRef} className="relative">
-				{/* Tooltip */}
 				<AnimatePresence>
 					{selectedIndex !== null && bars[selectedIndex] && (
 						<motion.div


### PR DESCRIPTION
## Summary
- `DebtEvolutionChart` and `StatsChart` now use shared hooks (`usePersistedPeriod`, `useOutsideClick`) and `PeriodSelector` component instead of duplicated inline implementations
- Removes ~30 lines of duplicated period state/localStorage/outside-click logic per chart component
- No behaviour change — visual and functional output is identical

## Test plan
- [ ] Stats tab: period selector works in both charts (DebtEvolutionChart and StatsChart)
- [ ] Period selection persists across page reloads (localStorage)
- [ ] Clicking outside a chart tooltip dismisses it
- [ ] No regressions in chart rendering or animations

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for version 1.14.0 with release notes.

* **Refactor**
  * Improved internal code organization and component structure for enhanced maintainability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->