### PR TITLE
fix(session): reset sujoodCountRef in useProximitySensor on manual prayer transition

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,16 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.16.0',
+		date: '2026-03-26',
+		changes: {
+			fr: [
+				"Correction : le compteur de sujouds se réinitialise correctement lors d'une transition manuelle entre prières",
+			],
+			en: ['Fix: sujood counter now resets correctly on manual prayer transition'],
+		},
+	},
+	{
 		version: '1.15.0',
 		date: '2026-03-26',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -367,7 +367,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 		}
 	}
 
-	const sensorState = useProximitySensor(
+	const { resetSujoodCount, ...sensorState } = useProximitySensor(
 		phase === 'active',
 		() => {
 			navigator.vibrate?.(100);
@@ -456,6 +456,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 			await logBatch([{ prayer: current.prayer, quantity: 1 }], sessionId);
 			setCurrentRakat(0);
 			setSujoodCount(0);
+			resetSujoodCount();
 			setConfirmDone(false);
 
 			setCompleted((prev) => {

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type SensorState = 'idle' | 'waiting_first' | 'waiting_second' | 'unsupported';
 
@@ -6,6 +6,7 @@ interface UseProximitySensorResult {
 	isSupported: boolean;
 	isActive: boolean;
 	currentState: SensorState;
+	resetSujoodCount: () => void;
 }
 
 const TILT_DOWN_THRESHOLD = 50;
@@ -286,9 +287,15 @@ export function useProximitySensor(
 		return setupCleanup(timerCleanup);
 	}, [active]);
 
+	const resetSujoodCount = useCallback(() => {
+		sujoodCountRef.current = 0;
+		setCurrentState('waiting_first');
+	}, []);
+
 	return {
 		isSupported,
 		isActive: active && isSupported && currentState !== 'idle',
 		currentState: isSupported ? currentState : 'unsupported',
+		resetSujoodCount,
 	};
 }


### PR DESCRIPTION
## Summary
- Exposes `resetSujoodCount()` from `useProximitySensor` — resets `sujoodCountRef.current` to `0` and `currentState` to `waiting_first`
- Calls `resetSujoodCount()` in `handleIncrement` (Session.tsx) after `setSujoodCount(0)`, fixing the bug where manual prayer transition left the hook's internal ref at `1`

## Root cause
When a user manually completes a prayer (taps Done mid-rakat → confirms), `active` stays `true` so the hook's `useEffect([active])` never re-runs. The `sujoodCountRef` was stuck at `1`, causing the next prayer's first sensor detection to be treated as the second sujood.

## Test plan
- [ ] Start session, detect first sujood (sensor), then tap Done → confirm → prayer transitions
- [ ] On the next prayer: first sensor detection should trigger `onFirstSujood` (vibrate 100ms), not `onSecondSujood`
- [ ] Normal sensor path (both sujoods detected automatically) remains unaffected

Closes #109