### PR TITLE
feat(logger): afficher l'onglet Historique par défaut

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.21.0',
+		date: '2026-03-26',
+		changes: {
+			fr: ["Logger : l'onglet Historique s'affiche en premier par défaut"],
+			en: ['Logger: History tab is shown by default on open'],
+		},
+	},
+	{
 		version: '1.20.0',
 		date: '2026-03-26',
 		changes: {

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -353,9 +353,9 @@ export function LogPrayers() {
 	const { t } = useTranslation();
 	const { logBatch, undoLastLog, recentLogs } = usePrayerStore();
 	const [quantities, setQuantities] = useState<Record<PrayerName, number>>(EMPTY);
-	const [activeTab, setActiveTab] = useState<Tab>('logger');
+	const [activeTab, setActiveTab] = useState<Tab>('history');
 	const [tabDir, setTabDir] = useState<1 | -1>(1);
-	const prevTabRef = useRef<Tab>('logger');
+	const prevTabRef = useRef<Tab>('history');
 
 	const total = PRAYER_NAMES.reduce((sum, p) => sum + quantities[p], 0);
 


### PR DESCRIPTION
## Summary

• Default active tab on Logger page changed from `logger` to `history`
• `prevTabRef` initial value updated to match (used for slide direction)

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for version 1.21.0 with localized content in French and English.

* **Changes**
  * LogPrayers now defaults to opening on the History tab instead of the Logger tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->