### PR TITLE
feat(app): show update toast with version number after PWA update

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"react-i18next": "^16.6.0",
+		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.2.0",
 		"workbox-window": "^7.4.0",
 		"zustand": "5.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-i18next:
         specifier: ^16.6.0
         version: 16.6.0(i18next@25.10.2(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.5.0
@@ -2682,6 +2685,12 @@ packages:
   smob@1.6.1:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
     engines: {node: '>=20.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5686,6 +5695,11 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   smob@1.6.1: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useRegisterSW } from 'virtual:pwa-register/react';
 import { AnimatePresence } from 'motion/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Toaster, toast } from 'sonner';
 import { BottomNav } from '@/components/BottomNav';
 import { InstallBanner } from '@/components/InstallBanner';
 import { MilestoneModal } from '@/components/MilestoneModal';
@@ -73,13 +74,27 @@ export function App() {
 	}, []);
 
 	useEffect(() => {
+		if (localStorage.getItem('pwa_updated')) {
+			localStorage.removeItem('pwa_updated');
+			toast.success(`v${__APP_VERSION__}`, {
+				description: t('app.updateSuccess'),
+				duration: 4000,
+			});
+		}
+	}, [t]);
+
+	useEffect(() => {
 		if (!needRefresh) return;
-		if (document.hidden) {
+		const triggerUpdate = () => {
+			localStorage.setItem('pwa_updated', '1');
 			updateServiceWorker(true);
+		};
+		if (document.hidden) {
+			triggerUpdate();
 			return;
 		}
 		const handleHide = () => {
-			if (document.hidden) updateServiceWorker(true);
+			if (document.hidden) triggerUpdate();
 		};
 		document.addEventListener('visibilitychange', handleHide);
 		return () => document.removeEventListener('visibilitychange', handleHide);
@@ -141,6 +156,17 @@ export function App() {
 			</AnimatePresence>
 			<MilestoneModal milestone={pendingMilestone} onClose={clearMilestone} />
 			<BottomNav activeTab={activeTab} onTabChange={handleTabChange} />
+			<Toaster
+				position="top-center"
+				toastOptions={{
+					style: {
+						background: 'var(--surface-raised)',
+						border: '1px solid var(--border)',
+						color: 'var(--text-primary)',
+						fontFamily: 'inherit',
+					},
+				}}
+			/>
 		</div>
 	);
 }

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.19.0',
+		date: '2026-03-29',
+		changes: {
+			fr: ["Notification de mise \u00e0 jour : un toast s\u2019affiche avec le num\u00e9ro de version apr\u00e8s chaque mise \u00e0 jour de l\u2019application"],
+			en: ['Update notification: a toast appears with the version number after each app update'],
+		},
+	},
+	{
 		version: '1.18.0',
 		date: '2026-03-29',
 		changes: {

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -21,6 +21,7 @@ export function useVersionCheck(): void {
 				}
 
 				if (data.version !== currentVersionRef.current) {
+					localStorage.setItem('pwa_updated', '1');
 					if (document.hidden) {
 						window.location.reload();
 					} else {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,9 @@
 		"years": "Years",
 		"months": "Months"
 	},
+	"app": {
+		"updateSuccess": "Update installed successfully"
+	},
 	"nav": {
 		"home": "HOME",
 		"log": "LOG",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,9 @@
 		"years": "Années",
 		"months": "Mois"
 	},
+	"app": {
+		"updateSuccess": "Mise à jour installée avec succès"
+	},
 	"nav": {
 		"home": "ACCUEIL",
 		"log": "LOGGER",


### PR DESCRIPTION
## Summary

• Install **sonner** for toast notifications
• After any PWA update (SW or version polling), set a `localStorage` flag before the reload
• On next mount, if flag exists: show `toast.success('vX.X.X', { description: '...' })` and clear the flag
• Both update paths covered: `useRegisterSW` (service worker) and `useVersionCheck` (version polling)
• Toaster styled with design system tokens (dark surface, gold-compatible)

## Type

feat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now receive an automatic success notification whenever the app is updated and a new version becomes active, providing confirmation of the update completion
  * Update notification messages are now available in both English and French languages

* **Documentation**
  * The changelog has been updated with version 1.19.0 release information and details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->