### PR TITLE
fix(session): move encouragement message above start button

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.20.0',
+		date: '2026-03-29',
+		changes: {
+			fr: ["Session : le message d\u2019encouragement est maintenant affiché au-dessus du bouton Démarrer"],
+			en: ['Session: encouragement message is now displayed above the Start button'],
+		},
+	},
+	{
 		version: '1.19.0',
 		date: '2026-03-29',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -610,6 +610,8 @@ export function Session({ onClose }: { onClose: () => void }) {
 							</AnimatePresence>
 						</motion.div>
 
+						<EncouragementMessage />
+
 						<motion.button
 							onClick={handleStart}
 							disabled={target === 0}
@@ -635,8 +637,6 @@ export function Session({ onClose }: { onClose: () => void }) {
 						>
 							{t('session.cancel')}
 						</motion.button>
-
-						<EncouragementMessage />
 					</motion.div>
 				)}
 


### PR DESCRIPTION
## Summary

• Moves the Islamic encouragement message above the Start button in session setup
• Ensures the message is visible before the user starts, not hidden below the fold