### PR TITLE
feat(log): show seconds in session duration

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.21.0',
+		date: '2026-03-29',
+		changes: {
+			fr: ["Historique : la dur\u00e9e des sessions affiche maintenant les minutes et les secondes"],
+			en: ['History: session duration now displays minutes and seconds'],
+		},
+	},
+	{
 		version: '1.20.0',
 		date: '2026-03-29',
 		changes: {

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -243,14 +243,16 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 				{groups.map((group, gi) => {
 					const totalPrayers = group.entries.reduce((s, e) => s + e.quantity, 0);
 					const isSession = group.sessionId?.startsWith('session-') ?? false;
-					const durationMin =
+					const durationSec =
 						isSession && group.entries.length > 1
 							? Math.floor(
 									(new Date(group.entries[0].logged_at).getTime() -
 										new Date(group.entries[group.entries.length - 1].logged_at).getTime()) /
-										60000,
+										1000,
 								)
 							: 0;
+					const durationMin = Math.floor(durationSec / 60);
+					const durationRemSec = durationSec % 60;
 
 					return (
 						<motion.div
@@ -285,9 +287,13 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 								>
 									+{totalPrayers}
 								</span>
-								{durationMin >= 1 && (
+								{durationSec >= 1 && (
 									<span className="text-[10px]" style={{ color: '#4A4A4C' }}>
-										{durationMin} min
+										{durationMin >= 1
+											? durationRemSec > 0
+												? `${durationMin} min ${durationRemSec}s`
+												: `${durationMin} min`
+											: `${durationSec}s`}
 									</span>
 								)}
 							</div>


### PR DESCRIPTION
## Summary

• Session duration in history now shows seconds: `45s`, `1 min 23s`, `2 min`
• Previously only showed full minutes (hidden if < 1 min)