### PR TITLE
fix(pwa): app works offline from first visit

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -15,9 +15,11 @@ const ENTRIES: ChangelogEntry[] = [
 		changes: {
 			fr: [
 				"Correctif : l'application fonctionne désormais hors ligne dès la première visite — le service worker prend le contrôle immédiatement et sert index.html pour toutes les navigations",
+				'robots.txt et sitemap.xml exclus du fallback de navigation du service worker',
 			],
 			en: [
 				'Fix: app now works offline from the first visit — service worker claims clients immediately and serves index.html for all navigation requests',
+				'robots.txt and sitemap.xml excluded from SW navigation fallback',
 			],
 		},
 	},

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,18 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.27.0',
+		date: '2026-04-10',
+		changes: {
+			fr: [
+				"Correctif : l'application fonctionne désormais hors ligne dès la première visite — le service worker prend le contrôle immédiatement et sert index.html pour toutes les navigations",
+			],
+			en: [
+				'Fix: app now works offline from the first visit — service worker claims clients immediately and serves index.html for all navigation requests',
+			],
+		},
+	},
+	{
 		version: '1.25.0',
 		date: '2026-04-10',
 		changes: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,9 +78,18 @@ export default defineConfig({
 			workbox: {
 				globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
 				cleanupOutdatedCaches: true,
+				// Claim uncontrolled clients on first cold install so offline works
+				// after a single online visit. Has no effect on the update path
+				// (skipWaiting is still deferred to the prompt flow via registerType: 'prompt').
 				clientsClaim: true,
 				navigateFallback: '/index.html',
-				navigateFallbackDenylist: [/^\/version\.json$/, /^\/privacy\.html$/, /^\/llms\.txt$/],
+				navigateFallbackDenylist: [
+					/^\/version\.json$/,
+					/^\/robots\.txt$/,
+					/^\/sitemap\.xml$/,
+					/^\/privacy\.html$/,
+					/^\/llms\.txt$/,
+				],
 				runtimeCaching: [
 					{
 						urlPattern: /^https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/i,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
 			workbox: {
 				globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
 				cleanupOutdatedCaches: true,
+				clientsClaim: true,
+				navigateFallback: '/index.html',
 				navigateFallbackDenylist: [/^\/version\.json$/, /^\/privacy\.html$/, /^\/llms\.txt$/],
 				runtimeCaching: [
 					{


### PR DESCRIPTION
## Problème

L'application affichait une page blanche au lancement sans connexion internet.

**Deux causes identifiées dans `vite.config.ts` :**

### 1. `navigateFallback` manquant
Sans cette option, Workbox ne savait pas servir `index.html` pour les requêtes de navigation hors ligne. Le browser obtenait une erreur réseau → page blanche.

### 2. `clientsClaim` absent
Avec `registerType: 'prompt'` sans `clientsClaim: true`, le service worker s'activait mais ne prenait pas le contrôle de la page courante. Il fallait **2 visites en ligne** avant que le mode offline fonctionne.

## Fix

```diff
workbox: {
+  clientsClaim: true,
+  navigateFallback: '/index.html',
   navigateFallbackDenylist: [/^\/version\.json$/, /^\/privacy\.html$/, /^\/llms\.txt$/],
```

- `clientsClaim: true` → le SW prend le contrôle immédiatement après activation (dès la 1ère visite)
- `navigateFallback: '/index.html'` → toutes les navigations servent le SPA shell depuis le cache
- La `navigateFallbackDenylist` existante exclut déjà `privacy.html` et `llms.txt` ✓

Vérifié dans le SW généré : `s.clientsClaim()` + `NavigationRoute("/index.html")` présents.

## Test plan

- [ ] Ouvrir l'app en ligne une première fois
- [ ] Passer en mode avion
- [ ] Fermer et rouvrir l'app → doit afficher le tableau de bord, pas une page blanche
- [ ] Vérifier que `/privacy.html` et `/llms.txt` restent accessibles directement (non interceptés par le SW)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced offline support with improved app navigation when connectivity is unavailable
  * Optimized offline behavior with better fallback handling
  * Certain resources now properly excluded from offline caching

* **Documentation**
  * Added version 1.27.0 changelog documenting offline experience improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->