### PR TITLE
feat(session): tashahhud pause after last sujood

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.28.0',
+		date: '2026-04-10',
+		changes: {
+			fr: [
+				'Session : pause tachahoud après le dernier sujoud — un décompte s\'affiche et le bouton "Fin de prière" permet de terminer manuellement (la durée réelle est sauvegardée comme nouvelle valeur par défaut)',
+				'Réglages : durée du tachahoud configurable (visible quand le suivi sujoud est activé)',
+			],
+			en: [
+				'Session: tashahhud pause after last sujood — a countdown appears and the "End Prayer" button ends the prayer manually (the actual elapsed time is saved as the new default)',
+				'Settings: configurable tashahhud duration (visible when sujood tracking is enabled)',
+			],
+		},
+	},
+	{
 		version: '1.27.0',
 		date: '2026-04-10',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, ChevronsUpDown, Timer } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { EncouragementMessage } from '@/components/EncouragementMessage';
 import { PRAYER_CONFIG } from '@/constants/prayers';
 import { useAvgPacePerPrayer } from '@/hooks/useAvgPacePerPrayer';
@@ -317,7 +318,6 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const sessionOrder = usePrayerStore((s) => s.sessionOrder);
 	const sujoodTrackingEnabled = usePrayerStore((s) => s.sujoodTrackingEnabled);
 	const sessionsPerDay = usePrayerStore((s) => s.sessionsPerDay);
-	const tashahdDurationMs = usePrayerStore((s) => s.tashahdDurationMs);
 	const setTashahdDurationMs = usePrayerStore((s) => s.setTashahdDurationMs);
 
 	const defaultTarget = computeTarget(activeObjective, sessionsPerDay);
@@ -354,6 +354,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const [currentRakat, setCurrentRakat] = useState(0);
 	const [tashahdActive, setTashahdActive] = useState(false);
 	const [tashahdSecondsLeft, setTashahdSecondsLeft] = useState(0);
+	const [tashahdTotalSeconds, setTashahdTotalSeconds] = useState(0);
 	const tashahdStartRef = useRef<number>(0);
 	const tashahdPendingRef = useRef(false);
 	const autoIncrementRef = useRef<() => void>(() => {});
@@ -526,7 +527,9 @@ export function Session({ onClose }: { onClose: () => void }) {
 	useEffect(() => {
 		if (!tashahdActive) return;
 		const durationMs = usePrayerStore.getState().tashahdDurationMs;
-		setTashahdSecondsLeft(Math.ceil(durationMs / 1000));
+		const totalSec = Math.ceil(durationMs / 1000);
+		setTashahdTotalSeconds(totalSec);
+		setTashahdSecondsLeft(totalSec);
 
 		const iv = setInterval(() => {
 			const remaining = Math.ceil((durationMs - (Date.now() - tashahdStartRef.current)) / 1000);
@@ -554,6 +557,9 @@ export function Session({ onClose }: { onClose: () => void }) {
 		const rounded = Math.round(elapsed / 1000) * 1000;
 		if (rounded >= 5000 && rounded <= 300000) {
 			setTashahdDurationMs(rounded);
+			toast.success(t('session.tashahdDurationSaved', { seconds: Math.round(rounded / 1000) }), {
+				duration: 2500,
+			});
 		}
 		tashahdPendingRef.current = false;
 		setTashahdActive(false);
@@ -813,8 +819,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 													2 *
 													Math.PI *
 													40 *
-													(1 -
-														tashahdSecondsLeft / Math.max(1, Math.ceil(tashahdDurationMs / 1000)))
+													(1 - tashahdSecondsLeft / Math.max(1, tashahdTotalSeconds))
 												}
 												transform="rotate(-90 48 48)"
 												transition={{ duration: 0.5, ease: 'linear' }}

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -38,17 +38,14 @@ function RakatDots({ total, current, color }: { total: number; current: number; 
 				const isActive = i === current;
 				return (
 					<motion.div
+						// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length array, items never reorder
 						key={i}
 						animate={
 							isActive
 								? { scale: [1, 1.18, 1], opacity: 1 }
 								: { scale: 1, opacity: isPast ? 0.5 : 0.3 }
 						}
-						transition={
-							isActive
-								? { duration: 1.8, repeat: Infinity, ease: 'easeInOut' }
-								: spring
-						}
+						transition={isActive ? { duration: 1.8, repeat: Infinity, ease: 'easeInOut' } : spring}
 						style={{
 							width: isActive ? 20 : 14,
 							height: isActive ? 20 : 14,
@@ -320,6 +317,8 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const sessionOrder = usePrayerStore((s) => s.sessionOrder);
 	const sujoodTrackingEnabled = usePrayerStore((s) => s.sujoodTrackingEnabled);
 	const sessionsPerDay = usePrayerStore((s) => s.sessionsPerDay);
+	const tashahdDurationMs = usePrayerStore((s) => s.tashahdDurationMs);
+	const setTashahdDurationMs = usePrayerStore((s) => s.setTashahdDurationMs);
 
 	const defaultTarget = computeTarget(activeObjective, sessionsPerDay);
 
@@ -353,6 +352,11 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const [pressing, setPressing] = useState(false);
 	const [sujoodCount, setSujoodCount] = useState<0 | 1>(0);
 	const [currentRakat, setCurrentRakat] = useState(0);
+	const [tashahdActive, setTashahdActive] = useState(false);
+	const [tashahdSecondsLeft, setTashahdSecondsLeft] = useState(0);
+	const tashahdStartRef = useRef<number>(0);
+	const tashahdPendingRef = useRef(false);
+	const autoIncrementRef = useRef<() => void>(() => {});
 	const busyRef = useRef(false);
 	const wakeLockRef = useRef<WakeLockSentinel | null>(null);
 
@@ -362,7 +366,13 @@ export function Session({ onClose }: { onClose: () => void }) {
 		const totalRakat = PRAYER_CONFIG[entry.prayer].rakat;
 		const next = currentRakat + 1;
 		if (next >= totalRakat) {
-			handleAutoIncrement();
+			if (sujoodTrackingEnabled) {
+				tashahdStartRef.current = Date.now();
+				tashahdPendingRef.current = true;
+				setTashahdActive(true);
+			} else {
+				handleAutoIncrement();
+			}
 		} else {
 			setCurrentRakat(next);
 			setConfirmDone(false);
@@ -370,7 +380,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 	}
 
 	const { resetSujoodCount, ...sensorState } = useProximitySensor(
-		phase === 'active' && sujoodTrackingEnabled,
+		phase === 'active' && sujoodTrackingEnabled && !tashahdActive,
 		() => {
 			navigator.vibrate?.(100);
 			setSujoodCount(1);
@@ -510,6 +520,45 @@ export function Session({ onClose }: { onClose: () => void }) {
 		}
 	};
 	const handleAutoIncrement = () => handleIncrement(false);
+
+	autoIncrementRef.current = handleAutoIncrement;
+
+	useEffect(() => {
+		if (!tashahdActive) return;
+		const durationMs = usePrayerStore.getState().tashahdDurationMs;
+		setTashahdSecondsLeft(Math.ceil(durationMs / 1000));
+
+		const iv = setInterval(() => {
+			const remaining = Math.ceil((durationMs - (Date.now() - tashahdStartRef.current)) / 1000);
+			setTashahdSecondsLeft(Math.max(0, remaining));
+		}, 500);
+
+		const to = setTimeout(() => {
+			clearInterval(iv);
+			if (tashahdPendingRef.current) {
+				tashahdPendingRef.current = false;
+				setTashahdActive(false);
+				autoIncrementRef.current();
+			}
+		}, durationMs);
+
+		return () => {
+			clearInterval(iv);
+			clearTimeout(to);
+		};
+	}, [tashahdActive]);
+
+	function handleTashahdEnd() {
+		if (!tashahdPendingRef.current) return;
+		const elapsed = Date.now() - tashahdStartRef.current;
+		const rounded = Math.round(elapsed / 1000) * 1000;
+		if (rounded >= 5000 && rounded <= 300000) {
+			setTashahdDurationMs(rounded);
+		}
+		tashahdPendingRef.current = false;
+		setTashahdActive(false);
+		autoIncrementRef.current();
+	}
 
 	const sessionPrayersRemaining = target - completed;
 	let sessionRakatsRemaining = 0;
@@ -680,7 +729,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 							</motion.div>
 						)}
 
-						{sensorState.isSupported && sensorState.isActive && (
+						{!tashahdActive && sensorState.isSupported && sensorState.isActive && (
 							<motion.div
 								className="w-full mb-6 px-4 py-3 rounded-2xl text-center text-sm font-medium"
 								style={{ background: '#242426', color: '#C9A962' }}
@@ -692,40 +741,43 @@ export function Session({ onClose }: { onClose: () => void }) {
 							</motion.div>
 						)}
 
-						{sujoodTrackingEnabled && !sensorState.isSupported && phase === 'active' && (
-							<motion.button
-								onClick={() => {
-									if (sujoodCount === 0) {
-										navigator.vibrate?.(100);
-										setSujoodCount(1);
-									} else if (!busyRef.current) {
-										navigator.vibrate?.([50, 50, 150]);
-										setSujoodCount(0);
-										handleRakatComplete();
+						{!tashahdActive &&
+							sujoodTrackingEnabled &&
+							!sensorState.isSupported &&
+							phase === 'active' && (
+								<motion.button
+									onClick={() => {
+										if (sujoodCount === 0) {
+											navigator.vibrate?.(100);
+											setSujoodCount(1);
+										} else if (!busyRef.current) {
+											navigator.vibrate?.([50, 50, 150]);
+											setSujoodCount(0);
+											handleRakatComplete();
+										}
+									}}
+									className="w-full mb-6 py-5 rounded-2xl text-center font-semibold tracking-[1px]"
+									style={
+										sujoodCount === 0
+											? { background: '#242426', border: '1px solid #3A3A3C', color: '#C9A962' }
+											: { background: '#C9A962', color: '#1A1A1C' }
 									}
-								}}
-								className="w-full mb-6 py-5 rounded-2xl text-center font-semibold tracking-[1px]"
-								style={
-									sujoodCount === 0
-										? { background: '#242426', border: '1px solid #3A3A3C', color: '#C9A962' }
-										: { background: '#C9A962', color: '#1A1A1C' }
-								}
-								initial={{ opacity: 0, y: -8 }}
-								animate={
-									sujoodCount === 1
-										? { opacity: 1, y: 0, scale: [1, 1.05, 1] }
-										: { opacity: 1, y: 0, scale: 1 }
-								}
-								transition={
-									sujoodCount === 1
-										? { duration: 0.8, repeat: Infinity, ease: 'easeInOut' }
-										: { delay: 0.1, ...spring }
-								}
-								whileTap={{ scale: 0.93 }}
-							>
-								{sujoodCount === 0 ? t('session.manualSujood1') : t('session.manualSujood2')}
-							</motion.button>
-						)}
+									initial={{ opacity: 0, y: -8 }}
+									animate={
+										sujoodCount === 1
+											? { opacity: 1, y: 0, scale: [1, 1.05, 1] }
+											: { opacity: 1, y: 0, scale: 1 }
+									}
+									transition={
+										sujoodCount === 1
+											? { duration: 0.8, repeat: Infinity, ease: 'easeInOut' }
+											: { delay: 0.1, ...spring }
+									}
+									whileTap={{ scale: 0.93 }}
+								>
+									{sujoodCount === 0 ? t('session.manualSujood1') : t('session.manualSujood2')}
+								</motion.button>
+							)}
 
 						{cfg.rakat > 1 && (
 							<RakatDots total={cfg.rakat} current={currentRakat} color={cfg.hex} />
@@ -736,7 +788,68 @@ export function Session({ onClose }: { onClose: () => void }) {
 						</AnimatePresence>
 
 						<AnimatePresence mode="wait">
-							{confirmDone ? (
+							{tashahdActive ? (
+								<motion.div
+									key="tashahd"
+									className="mt-8 w-full flex flex-col items-center gap-5"
+									initial={{ opacity: 0, y: 20 }}
+									animate={{ opacity: 1, y: 0 }}
+									exit={{ opacity: 0, y: -20 }}
+									transition={spring}
+								>
+									<div className="relative flex items-center justify-center">
+										<svg width="96" height="96" viewBox="0 0 96 96" aria-hidden="true">
+											<circle cx="48" cy="48" r="40" fill="none" stroke="#3A3A3C" strokeWidth="4" />
+											<motion.circle
+												cx="48"
+												cy="48"
+												r="40"
+												fill="none"
+												stroke="#C9A962"
+												strokeWidth="4"
+												strokeLinecap="round"
+												strokeDasharray={2 * Math.PI * 40}
+												strokeDashoffset={
+													2 *
+													Math.PI *
+													40 *
+													(1 -
+														tashahdSecondsLeft / Math.max(1, Math.ceil(tashahdDurationMs / 1000)))
+												}
+												transform="rotate(-90 48 48)"
+												transition={{ duration: 0.5, ease: 'linear' }}
+											/>
+										</svg>
+										<span
+											className="absolute text-2xl font-semibold tabular-nums"
+											style={{ color: '#C9A962' }}
+										>
+											{tashahdSecondsLeft}
+										</span>
+									</div>
+									<div className="text-center">
+										<p className="text-sm font-medium" style={{ color: '#F5F5F0' }}>
+											{t('session.tashahd')}
+										</p>
+										<p className="text-xs mt-0.5" style={{ color: '#6E6E70' }}>
+											{t('session.tashahdDesc')}
+										</p>
+									</div>
+									<motion.button
+										onClick={handleTashahdEnd}
+										className="w-full rounded-[28px] py-5 text-base font-semibold tracking-[1.5px]"
+										style={{
+											background: 'linear-gradient(135deg, #C9A962, #8B7845)',
+											color: '#1A1A1C',
+										}}
+										whileTap={{ scale: 0.94 }}
+										whileHover={{ scale: 1.02 }}
+										transition={spring}
+									>
+										{t('session.tashahdEndPrayer')}
+									</motion.button>
+								</motion.div>
+							) : confirmDone ? (
 								<motion.div
 									key="confirm-done"
 									className="mt-8 flex flex-col items-center gap-3"

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -136,7 +136,10 @@
 		"completedCount_other": "{{count}} صلاة مقضية",
 		"close": "إغلاق",
 		"prayersRemaining": "صلوات متبقية",
-		"rakatsRemaining": "ركعات متبقية"
+		"rakatsRemaining": "ركعات متبقية",
+		"tashahd": "التشهد",
+		"tashahdDesc": "اقرأ التشهد قبل إنهاء الصلاة",
+		"tashahdEndPrayer": "إنهاء الصلاة"
 	},
 	"settings": {
 		"title": "الإعدادات",
@@ -166,6 +169,8 @@
 		"highestDebt": "أولوية الفوائت",
 		"sujoodTracking": "تتبع السجود",
 		"sujoodTrackingDesc": "الكشف التلقائي للسجود عبر مستشعرات الجهاز",
+		"tashahdDuration": "مدة التشهد",
+		"tashahdDurationDesc": "الوقت بين آخر سجدة ونهاية الصلاة",
 		"sessionsPerDay": "الجلسات / اليوم",
 		"sessionsPerDayDesc": "يُقسَّم الهدف اليومي على كل جلسة",
 		"notifications": "تذكير يومي",

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -139,7 +139,8 @@
 		"rakatsRemaining": "ركعات متبقية",
 		"tashahd": "التشهد",
 		"tashahdDesc": "اقرأ التشهد قبل إنهاء الصلاة",
-		"tashahdEndPrayer": "إنهاء الصلاة"
+		"tashahdEndPrayer": "إنهاء الصلاة",
+		"tashahdDurationSaved": "تم حفظ مدة التشهد: {{seconds}} ث"
 	},
 	"settings": {
 		"title": "الإعدادات",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,7 +112,10 @@
 		"completedCount_other": "{{count}} prayers completed",
 		"close": "CLOSE",
 		"prayersRemaining": "prayers remaining",
-		"rakatsRemaining": "rak'ats remaining"
+		"rakatsRemaining": "rak'ats remaining",
+		"tashahd": "Tashahhud",
+		"tashahdDesc": "Recite the tashahhud before ending the prayer",
+		"tashahdEndPrayer": "END PRAYER"
 	},
 	"settings": {
 		"title": "Settings",
@@ -142,6 +145,8 @@
 		"highestDebt": "Debt priority",
 		"sujoodTracking": "Sujood tracking",
 		"sujoodTrackingDesc": "Auto-detect sujood via device sensors",
+		"tashahdDuration": "Tashahhud duration",
+		"tashahdDurationDesc": "Time between the last sujood and the end of the prayer",
 		"sessionsPerDay": "Sessions / day",
 		"sessionsPerDayDesc": "The daily objective will be split across each session",
 		"notifications": "DAILY REMINDER",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,7 +115,8 @@
 		"rakatsRemaining": "rak'ats remaining",
 		"tashahd": "Tashahhud",
 		"tashahdDesc": "Recite the tashahhud before ending the prayer",
-		"tashahdEndPrayer": "END PRAYER"
+		"tashahdEndPrayer": "END PRAYER",
+		"tashahdDurationSaved": "Tashahhud: {{seconds}}s saved"
 	},
 	"settings": {
 		"title": "Settings",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -112,7 +112,10 @@
 		"completedCount_other": "{{count}} prières accomplies",
 		"close": "FERMER",
 		"prayersRemaining": "prières restantes",
-		"rakatsRemaining": "rak'ats restants"
+		"rakatsRemaining": "rak'ats restants",
+		"tashahd": "Tachahoud",
+		"tashahdDesc": "Récitez le tachahoud avant de terminer la prière",
+		"tashahdEndPrayer": "FIN DE PRIÈRE"
 	},
 	"settings": {
 		"title": "Réglages",
@@ -142,6 +145,8 @@
 		"highestDebt": "Priorité dette",
 		"sujoodTracking": "Suivi sujoud",
 		"sujoodTrackingDesc": "Détection automatique des sujoud via les capteurs",
+		"tashahdDuration": "Durée du tachahoud",
+		"tashahdDurationDesc": "Temps entre le dernier sujoud et la fin de la prière",
 		"sessionsPerDay": "Sessions / jour",
 		"sessionsPerDayDesc": "L'objectif du jour sera réparti entre chaque session",
 		"notifications": "RAPPEL QUOTIDIEN",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -115,7 +115,8 @@
 		"rakatsRemaining": "rak'ats restants",
 		"tashahd": "Tachahoud",
 		"tashahdDesc": "Récitez le tachahoud avant de terminer la prière",
-		"tashahdEndPrayer": "FIN DE PRIÈRE"
+		"tashahdEndPrayer": "FIN DE PRIÈRE",
+		"tashahdDurationSaved": "Tachahoud : {{seconds}}s enregistré"
 	},
 	"settings": {
 		"title": "Réglages",

--- a/src/pages/Settings/SessionTab.tsx
+++ b/src/pages/Settings/SessionTab.tsx
@@ -26,6 +26,8 @@ export function SessionTab() {
 		sessionOrder,
 		sujoodTrackingEnabled,
 		setSujoodTrackingEnabled,
+		tashahdDurationMs,
+		setTashahdDurationMs,
 		activeObjective,
 		sessionsPerDay,
 		setSessionsPerDay,
@@ -85,6 +87,43 @@ export function SessionTab() {
 							</span>
 						</button>
 					</div>
+					{sujoodTrackingEnabled && (
+						<>
+							<div className="h-px bg-border" />
+							<div className="flex items-center justify-between">
+								<div className="flex flex-col gap-0.5">
+									<span className="text-sm font-medium text-foreground">
+										{t('settings.tashahdDuration')}
+									</span>
+									<span className="text-[11px] text-muted">
+										{t('settings.tashahdDurationDesc')}
+									</span>
+								</div>
+								<div className="flex items-center gap-2">
+									<button
+										type="button"
+										onClick={() => setTashahdDurationMs(tashahdDurationMs - 5000)}
+										disabled={tashahdDurationMs <= 5000}
+										className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
+									>
+										−
+									</button>
+									<span className="min-w-[48px] text-center text-sm font-semibold tabular-nums text-foreground">
+										{Math.round(tashahdDurationMs / 1000)}
+										<span className="text-muted font-normal text-xs ml-0.5">s</span>
+									</span>
+									<button
+										type="button"
+										onClick={() => setTashahdDurationMs(tashahdDurationMs + 5000)}
+										disabled={tashahdDurationMs >= 300000}
+										className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
+									>
+										+
+									</button>
+								</div>
+							</div>
+						</>
+					)}
 					{activeObjective && (
 						<>
 							<div className="h-px bg-border" />

--- a/src/stores/prayerStore.ts
+++ b/src/stores/prayerStore.ts
@@ -78,6 +78,7 @@ export type SessionOrder = 'chronological' | 'highest-debt';
 const SESSION_ORDER_KEY = 'session-order';
 const SUJOOD_TRACKING_KEY = 'sujood-tracking-enabled';
 const SESSIONS_PER_DAY_KEY = 'sessions-per-day';
+const TASHAHD_DURATION_KEY = 'tashahd-duration-ms';
 
 interface PrayerStore {
 	debts: Record<PrayerName, PrayerDebt>;
@@ -88,6 +89,7 @@ interface PrayerStore {
 	sessionOrder: SessionOrder;
 	sujoodTrackingEnabled: boolean;
 	sessionsPerDay: number;
+	tashahdDurationMs: number;
 	pendingMilestone: number | null;
 
 	loadAll: () => Promise<void>;
@@ -102,6 +104,7 @@ interface PrayerStore {
 	setSessionOrder: (order: SessionOrder) => void;
 	setSujoodTrackingEnabled: (enabled: boolean) => void;
 	setSessionsPerDay: (value: number) => void;
+	setTashahdDurationMs: (ms: number) => void;
 	clearMilestone: () => void;
 	resetAll: () => Promise<void>;
 }
@@ -138,6 +141,10 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 		sessionsPerDay: (() => {
 			const raw = parseInt(localStorage.getItem(SESSIONS_PER_DAY_KEY) ?? '', 10);
 			return [1, 2, 3, 4, 5].includes(raw) ? raw : 1;
+		})(),
+		tashahdDurationMs: (() => {
+			const raw = parseInt(localStorage.getItem(TASHAHD_DURATION_KEY) ?? '', 10);
+			return raw >= 5000 && raw <= 300000 ? raw : 30000;
 		})(),
 		pendingMilestone: null,
 
@@ -218,6 +225,12 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 			if (![1, 2, 3, 4, 5].includes(value)) return;
 			localStorage.setItem(SESSIONS_PER_DAY_KEY, String(value));
 			set({ sessionsPerDay: value });
+		},
+
+		setTashahdDurationMs: (ms) => {
+			const clamped = Math.max(5000, Math.min(300000, ms));
+			localStorage.setItem(TASHAHD_DURATION_KEY, String(clamped));
+			set({ tashahdDurationMs: clamped });
 		},
 
 		clearMilestone: () => {


### PR DESCRIPTION
## Summary
- After the last sujood of each prayer, a countdown screen appears instead of immediately advancing to the next prayer
- Users can tap "End Prayer" to proceed — the elapsed time is auto-saved as the new default tashahhud duration
- Adds configurable tashahhud duration setting (5s–300s, default 30s) in session settings, visible when sujood tracking is enabled
- Countdown auto-advances when timer expires; sujood sensor is paused during the tashahhud phase
- Translations added for FR, EN, AR

## Test plan
- [ ] Enable sujood tracking in settings, verify "Durée du tachahoud" stepper appears
- [ ] Start a session, complete all rakats of a prayer via sujood detection
- [ ] Verify the countdown ring appears after last sujood instead of auto-advancing
- [ ] Tap "Fin de prière" before countdown ends — verify prayer logs and next prayer starts
- [ ] Let countdown expire — verify prayer auto-advances
- [ ] Verify elapsed time is saved as new default when tapping early
- [ ] Disable sujood tracking — verify no tashahhud pause, old behavior works
- [ ] Test manual sujood button (sensor unsupported) — verify tashahhud still triggers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced tashahd timer phase during prayer sessions when sujood tracking is enabled
  * Added customizable tashahd duration settings with increment/decrement controls
  * Multi-language support added for tashahd feature

* **Chores**
  * Updated changelog for version 1.28.0 release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->