### PR TITLE
feat(session): target adjustment, per-prayer timing, smarter pace estimate

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,22 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.29.0',
+		date: '2026-04-10',
+		changes: {
+			fr: [
+				'Session : boutons + / − pour ajuster le nombre de prières à rattraper pendant une session active',
+				"Session : l'estimation de durée se base désormais sur les 30 derniers jours de sessions ou les 30 dernières sessions",
+				'Historique : durée de chaque prière affichée dans les sessions',
+			],
+			en: [
+				'Session: + / − buttons to adjust the prayer target during an active session',
+				'Session: duration estimate now uses the last 30 days of sessions or the last 30 sessions',
+				'History: per-prayer duration now shown within session entries',
+			],
+		},
+	},
+	{
 		version: '1.28.0',
 		date: '2026-04-10',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -199,7 +199,17 @@ function getNextPrayer(
 	return null;
 }
 
-function AnimatedCounter({ value, target }: { value: number; target: number }) {
+function AnimatedCounter({
+	value,
+	target,
+	onDecrease,
+	onIncrease,
+}: {
+	value: number;
+	target: number;
+	onDecrease?: () => void;
+	onIncrease?: () => void;
+}) {
 	const [display, setDisplay] = useState(value);
 	const prevRef = useRef(value);
 
@@ -239,9 +249,31 @@ function AnimatedCounter({ value, target }: { value: number; target: number }) {
 				>
 					{display}
 				</motion.span>
-				<span className="text-2xl font-light mb-2" style={{ color: '#4A4A4C' }}>
-					/ {target}
-				</span>
+				<div className="flex flex-col items-center gap-1 mb-2">
+					{onIncrease && (
+						<button
+							type="button"
+							onClick={onIncrease}
+							className="flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium transition-opacity active:opacity-60"
+							style={{ color: '#C9A962', background: '#C9A96220' }}
+						>
+							+
+						</button>
+					)}
+					<span className="text-2xl font-light" style={{ color: '#4A4A4C' }}>
+						/ {target}
+					</span>
+					{onDecrease && (
+						<button
+							type="button"
+							onClick={onDecrease}
+							className="flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium transition-opacity active:opacity-60"
+							style={{ color: '#C9A962', background: '#C9A96220' }}
+						>
+							−
+						</button>
+					)}
+				</div>
 			</div>
 
 			{/* Progress bar */}
@@ -706,7 +738,18 @@ export function Session({ onClose }: { onClose: () => void }) {
 							animate={{ opacity: 1, scale: 1 }}
 							transition={{ delay: 0.08, ...spring }}
 						>
-							<AnimatedCounter value={completed} target={target} />
+							<AnimatedCounter
+								value={completed}
+								target={target}
+								onDecrease={
+									!tashahdActive && target > completed + 1 ? () => setTarget(target - 1) : undefined
+								}
+								onIncrease={
+									!tashahdActive && target < MAX_PICKER_VALUE
+										? () => setTarget(target + 1)
+										: undefined
+								}
+							/>
 						</motion.div>
 
 						{effectiveRakatsRemaining > 0 && (

--- a/src/hooks/useAvgPacePerPrayer.ts
+++ b/src/hooks/useAvgPacePerPrayer.ts
@@ -2,14 +2,30 @@ import { useEffect, useState } from 'react';
 import { db } from '@/db/database';
 import { getRecentLogs } from '@/db/queries';
 import { calculateAvgPacePerPrayer } from '@/lib/calculateAvgPacePerPrayer';
+import type { PrayerLog } from '@/types';
 
-const LOGS_FOR_PACE = 200;
+// Fetch enough recent logs to cover both windows (30 sessions × up to 20 prayers each)
+const LOGS_FOR_PACE = 600;
+const DAYS_WINDOW = 30;
 
 export function useAvgPacePerPrayer(): number | null {
 	const [pace, setPace] = useState<number | null>(null);
 	useEffect(() => {
-		getRecentLogs(db, LOGS_FOR_PACE)
-			.then((logs) => setPace(calculateAvgPacePerPrayer(logs)))
+		const cutoffDate = new Date(Date.now() - DAYS_WINDOW * 24 * 60 * 60 * 1000).toISOString();
+		Promise.all([
+			getRecentLogs(db, LOGS_FOR_PACE),
+			db.prayer_logs.where('logged_at').aboveOrEqual(cutoffDate).toArray(),
+		])
+			.then(([recent, windowed]: [PrayerLog[], PrayerLog[]]) => {
+				const seen = new Set<number>();
+				const merged: PrayerLog[] = [];
+				for (const log of [...recent, ...windowed]) {
+					if (log.id !== undefined && seen.has(log.id)) continue;
+					if (log.id !== undefined) seen.add(log.id);
+					merged.push(log);
+				}
+				setPace(calculateAvgPacePerPrayer(merged));
+			})
 			.catch(() => {});
 	}, []);
 	return pace;

--- a/src/hooks/useAvgPacePerPrayer.ts
+++ b/src/hooks/useAvgPacePerPrayer.ts
@@ -17,11 +17,15 @@ export function useAvgPacePerPrayer(): number | null {
 			db.prayer_logs.where('logged_at').aboveOrEqual(cutoffDate).toArray(),
 		])
 			.then(([recent, windowed]: [PrayerLog[], PrayerLog[]]) => {
-				const seen = new Set<number>();
+				const seen = new Set<string>();
 				const merged: PrayerLog[] = [];
 				for (const log of [...recent, ...windowed]) {
-					if (log.id !== undefined && seen.has(log.id)) continue;
-					if (log.id !== undefined) seen.add(log.id);
+					const key =
+						log.id !== undefined
+							? `id:${log.id}`
+							: `${log.logged_at}_${log.session_id}_${log.prayer}`;
+					if (seen.has(key)) continue;
+					seen.add(key);
 					merged.push(log);
 				}
 				setPace(calculateAvgPacePerPrayer(merged));

--- a/src/lib/calculateAvgPacePerPrayer.test.ts
+++ b/src/lib/calculateAvgPacePerPrayer.test.ts
@@ -50,15 +50,29 @@ describe('calculateAvgPacePerPrayer', () => {
 		expect(calculateAvgPacePerPrayer(logs)).toBe(18000);
 	});
 
-	it('caps at 20 most recent sessions', () => {
-		// Build 25 sessions, each with 2 logs 60s apart, qty=1 each → 60000ms / 2 = 30000ms/prayer
+	it('caps at 30 most recent sessions', () => {
+		// Build 35 sessions far in the past (> 30 days ago), each with 2 logs 60s apart, qty=1 → 30000ms/prayer
 		const logs: PrayerLog[] = [];
-		for (let i = 0; i < 25; i++) {
-			const base = new Date(`2025-01-${String(i + 1).padStart(2, '0')}T10:00:00.000Z`).getTime();
+		const oldBase = new Date('2020-01-01T10:00:00.000Z').getTime();
+		for (let i = 0; i < 35; i++) {
+			const base = oldBase + i * 24 * 60 * 60 * 1000;
 			logs.push(makeLog(`s${i}`, new Date(base + 60_000).toISOString()));
 			logs.push(makeLog(`s${i}`, new Date(base).toISOString()));
 		}
-		// All 25 sessions have pace 30000; average of any 20 is also 30000
+		// Only 30 most recent sessions are used; all have pace 30000 → average is 30000
+		expect(calculateAvgPacePerPrayer(logs)).toBe(30000);
+	});
+
+	it('includes sessions within the 30-day window even beyond the 30-session count', () => {
+		// 32 sessions all within the last 10 days → all should be included
+		const logs: PrayerLog[] = [];
+		const now = Date.now();
+		for (let i = 0; i < 32; i++) {
+			const base = now - i * 6 * 60 * 60 * 1000; // 6 hours apart
+			logs.push(makeLog(`s${i}`, new Date(base + 60_000).toISOString()));
+			logs.push(makeLog(`s${i}`, new Date(base).toISOString()));
+		}
+		// All 32 sessions have pace 30000ms; all within 30-day window so all included
 		expect(calculateAvgPacePerPrayer(logs)).toBe(30000);
 	});
 });

--- a/src/lib/calculateAvgPacePerPrayer.ts
+++ b/src/lib/calculateAvgPacePerPrayer.ts
@@ -1,6 +1,7 @@
 import type { PrayerLog } from '@/types';
 
-const MAX_SESSIONS = 20;
+const MAX_SESSIONS = 30;
+const DAYS_WINDOW = 30;
 
 export function calculateAvgPacePerPrayer(logs: PrayerLog[]): number | null {
 	const sessionMap = new Map<string, PrayerLog[]>();
@@ -11,8 +12,22 @@ export function calculateAvgPacePerPrayer(logs: PrayerLog[]): number | null {
 		sessionMap.set(log.session_id, arr);
 	}
 
+	const cutoff = Date.now() - DAYS_WINDOW * 24 * 60 * 60 * 1000;
+
+	// Sort sessions most-recent first so we can apply both windows correctly
+	const sessions = [...sessionMap.values()].sort((a, b) => {
+		const latestA = Math.max(...a.map((e) => new Date(e.logged_at).getTime()));
+		const latestB = Math.max(...b.map((e) => new Date(e.logged_at).getTime()));
+		return latestB - latestA;
+	});
+
 	const paces: number[] = [];
-	for (const entries of sessionMap.values()) {
+	for (let i = 0; i < sessions.length; i++) {
+		const entries = sessions[i];
+		const latestTime = Math.max(...entries.map((e) => new Date(e.logged_at).getTime()));
+		// Stop when both windows are exhausted
+		if (i >= MAX_SESSIONS && latestTime < cutoff) break;
+
 		if (entries.length < 2) continue;
 		const times = entries.map((e) => new Date(e.logged_at).getTime());
 		const duration = Math.max(...times) - Math.min(...times);
@@ -20,7 +35,6 @@ export function calculateAvgPacePerPrayer(logs: PrayerLog[]): number | null {
 		const totalQty = entries.reduce((sum, e) => sum + e.quantity, 0);
 		if (totalQty <= 0) continue;
 		paces.push(duration / totalQty);
-		if (paces.length === MAX_SESSIONS) break;
 	}
 
 	if (paces.length === 0) return null;

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -379,10 +379,13 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 						const isSession = group.sessionId?.startsWith('session-') ?? false;
 						const durationSec =
 							isSession && group.entries.length > 1
-								? Math.floor(
-										(new Date(group.entries[0].logged_at).getTime() -
-											new Date(group.entries[group.entries.length - 1].logged_at).getTime()) /
-											1000,
+								? Math.max(
+										0,
+										Math.floor(
+											(new Date(group.entries[0].logged_at).getTime() -
+												new Date(group.entries[group.entries.length - 1].logged_at).getTime()) /
+												1000,
+										),
 									)
 								: 0;
 

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -25,6 +25,13 @@ import { PRAYER_NAMES } from '@/types';
 const TABS = ['logger', 'history'] as const;
 type Tab = (typeof TABS)[number];
 
+function formatDuration(sec: number): string {
+	const min = Math.floor(sec / 60);
+	const remSec = sec % 60;
+	if (min >= 1) return remSec > 0 ? `${min} min ${remSec}s` : `${min} min`;
+	return `${sec}s`;
+}
+
 const EMPTY = (): Record<PrayerName, number> =>
 	Object.fromEntries(PRAYER_NAMES.map((p) => [p, 0])) as Record<PrayerName, number>;
 
@@ -378,8 +385,6 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 											1000,
 									)
 								: 0;
-						const durationMin = Math.floor(durationSec / 60);
-						const durationRemSec = durationSec % 60;
 
 						return (
 							<motion.div
@@ -416,11 +421,7 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 									</span>
 									{durationSec >= 1 && (
 										<span className="text-[10px]" style={{ color: '#4A4A4C' }}>
-											{durationMin >= 1
-												? durationRemSec > 0
-													? `${durationMin} min ${durationRemSec}s`
-													: `${durationMin} min`
-												: `${durationSec}s`}
+											{formatDuration(durationSec)}
 										</span>
 									)}
 								</div>
@@ -431,6 +432,15 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 								>
 									{group.entries.map((log, li) => {
 										const cfg = PRAYER_CONFIG[log.prayer];
+										const prevEntry = group.entries[li + 1];
+										const prayerDurationSec =
+											isSession && prevEntry
+												? Math.floor(
+														(new Date(log.logged_at).getTime() -
+															new Date(prevEntry.logged_at).getTime()) /
+															1000,
+													)
+												: null;
 										return (
 											<div key={log.id}>
 												{li > 0 && <div style={{ height: 1, background: '#2A2A2C' }} />}
@@ -459,20 +469,30 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 															{cfg.labelAr}
 														</span>
 													</div>
-													<motion.span
-														className="font-display text-lg font-medium tabular-nums"
-														style={{ color: '#C9A962' }}
-														initial={{ scale: 0.8, opacity: 0 }}
-														animate={{ scale: 1, opacity: 1 }}
-														transition={{
-															delay: gi * 0.04 + li * 0.03 + 0.05,
-															type: 'spring' as const,
-															stiffness: 500,
-															damping: 22,
-														}}
-													>
-														+{log.quantity}
-													</motion.span>
+													<div className="flex items-center gap-2">
+														{prayerDurationSec !== null && prayerDurationSec >= 1 && (
+															<span
+																className="text-[10px] tabular-nums"
+																style={{ color: '#3A3A3C' }}
+															>
+																{formatDuration(prayerDurationSec)}
+															</span>
+														)}
+														<motion.span
+															className="font-display text-lg font-medium tabular-nums"
+															style={{ color: '#C9A962' }}
+															initial={{ scale: 0.8, opacity: 0 }}
+															animate={{ scale: 1, opacity: 1 }}
+															transition={{
+																delay: gi * 0.04 + li * 0.03 + 0.05,
+																type: 'spring' as const,
+																stiffness: 500,
+																damping: 22,
+															}}
+														>
+															+{log.quantity}
+														</motion.span>
+													</div>
 												</motion.div>
 											</div>
 										);


### PR DESCRIPTION
## Summary

- **Session target adjustment**: +/− buttons on the animated counter during an active session let the user increase or decrease the target prayer count on the fly (min: `completed + 1`, max: 999, hidden during tashahud)
- **Per-prayer duration in history**: each prayer row within a session group in the History tab now shows how long that prayer took (computed from consecutive `logged_at` timestamps)
- **Smarter pace estimate**: the session setup time-estimate window is widened from last 20 sessions to last 30 days **or** last 30 sessions (union) — uses a Dexie `logged_at` date-range query merged with the recent-log fetch

## Test plan

- [ ] Open a session, start praying — +/− buttons appear beside the target; − is disabled when target equals completed+1; buttons disappear during tashahud countdown
- [ ] Complete a multi-prayer session, go to History — each prayer row shows its individual duration (except the first, which has no prior reference)
- [ ] First-time user (no history): pace estimate not shown (returns null as before)
- [ ] `calculateAvgPacePerPrayer` tests: 162 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added increment/decrement controls for adjusting prayer targets.
  * Session duration now displays alongside prayer quantities in logs.

* **Improvements**
  * Enhanced prayer pace calculations to use a broader data set for improved accuracy.

* **Documentation**
  * Updated changelog for version 1.29.0 (April 10, 2026) with localized entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->