### PR TITLE
fix(ui): replace hardcoded hex colors with CSS variable tokens in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,8 +109,11 @@ export function App() {
 
 	if (isLoading) {
 		return (
-			<div className="flex min-h-dvh items-center justify-center" style={{ background: '#1A1A1C' }}>
-				<span className="font-display text-2xl font-light" style={{ color: '#C9A962' }}>
+			<div
+				className="flex min-h-dvh items-center justify-center"
+				style={{ background: 'var(--background)' }}
+			>
+				<span className="font-display text-2xl font-light" style={{ color: 'var(--gold)' }}>
 					قضاء
 				</span>
 			</div>
@@ -145,7 +148,7 @@ export function App() {
 	};
 
 	return (
-		<div className="min-h-dvh" style={{ background: '#1A1A1C' }}>
+		<div className="min-h-dvh" style={{ background: 'var(--background)' }}>
 			<main className="mx-auto max-w-lg pt-safe pb-28 overflow-hidden">
 				<ErrorBoundary>
 					{(Object.keys(pages) as Tab[]).map(

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -19,6 +19,7 @@ const ENTRIES: ChangelogEntry[] = [
 				'Historique : durée de chaque prière affichée dans les sessions',
 				"Session : correction du premier soujoud qui s'incrémentait automatiquement après la fin du tachahoud",
 				"Session : suppression de la demande d'accès motion/orientation (non utilisée)",
+				"UI : couleurs de fond et d'accentuation du chargement initial remplacées par les tokens CSS du design system",
 			],
 			en: [
 				'Session: + / − buttons to adjust the prayer target during an active session',
@@ -26,6 +27,7 @@ const ENTRIES: ChangelogEntry[] = [
 				'History: per-prayer duration now shown within session entries',
 				'Session: fixed first sujood auto-incrementing after tashahhud ended',
 				'Session: removed unused motion/orientation access permission request',
+				'UI: loading screen background and accent colors now use CSS variable tokens instead of hardcoded hex',
 			],
 		},
 	},
@@ -633,8 +635,8 @@ const ENTRIES: ChangelogEntry[] = [
 		version: '1.0.25',
 		date: '2026-03-21',
 		changes: {
-			fr: ["Picker iOS style pour le nombre de rakats (chiffres précédent/suivant visibles)"],
-			en: ["iOS-style drum roll picker for rakat count (previous/next numbers visible)"],
+			fr: ['Picker iOS style pour le nombre de rakats (chiffres précédent/suivant visibles)'],
+			en: ['iOS-style drum roll picker for rakat count (previous/next numbers visible)'],
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

- Replace `'#1A1A1C'` with `var(--background)` in two loading/root divs
- Replace `'#C9A962'` with `var(--gold)` in the loading spinner text
- All three occurrences were pre-existing; flagged in code review on #158

## Test plan

- [ ] Verify loading screen still shows correct dark background and gold text
- [ ] Verify main app background is unchanged

Closes #159