### PR TITLE
fix(rtl): replace physical margin classes with logical properties for Arabic RTL support

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.29.3',
+		date: '2026-04-10',
+		changes: {
+			fr: [
+				'RTL : label des prières et compteur traduits sur tous les écrans (journal, historique, réglages)',
+				'RTL : label arabe masqué en mode arabe pour éviter la duplication',
+			],
+			en: [
+				'RTL: prayer labels and counter translated across all screens (logger, history, settings)',
+				'RTL: Arabic label hidden when Arabic is active to avoid duplication',
+			],
+		},
+	},
+	{
 		version: '1.29.0',
 		date: '2026-04-10',
 		changes: {

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -14,6 +14,8 @@ const ENTRIES: ChangelogEntry[] = [
 		date: '2026-04-10',
 		changes: {
 			fr: [
+				'RTL : classes directionnelles (ml-*, mr-*) remplacées par des propriétés logiques (ms-*, me-*) pour le support arabe',
+				'Composant prière : label et compteur traduits selon la langue active (fin du français codé en dur)',
 				'Session : boutons + / − pour ajuster le nombre de prières à rattraper pendant une session active',
 				"Session : l'estimation de durée se base désormais sur les 30 derniers jours de sessions ou les 30 dernières sessions",
 				'Historique : durée de chaque prière affichée dans les sessions',
@@ -22,6 +24,8 @@ const ENTRIES: ChangelogEntry[] = [
 				"UI : couleurs de fond et d'accentuation du chargement initial remplacées par les tokens CSS du design system",
 			],
 			en: [
+				'RTL: directional margin/padding classes (ml-*, mr-*) replaced with logical properties (ms-*, me-*) for Arabic support',
+				'Prayer component: label and counter now translated per active language (no more hardcoded French)',
 				'Session: + / − buttons to adjust the prayer target during an active session',
 				'Session: duration estimate now uses the last 30 days of sessions or the last 30 sessions',
 				'History: per-prayer duration now shown within session entries',

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -55,7 +55,7 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 						{t('installBanner.subtitle')}
 					</span>
 				</div>
-				<div className="flex gap-2 ml-4">
+				<div className="flex gap-2 ms-4">
 					<button
 						type="button"
 						onClick={handleInstall}

--- a/src/components/PrayerCounter.tsx
+++ b/src/components/PrayerCounter.tsx
@@ -1,4 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -12,7 +13,14 @@ interface PrayerCounterProps {
 }
 
 export function PrayerCounter({ prayer, debt, onLog }: PrayerCounterProps) {
+	const { t, i18n } = useTranslation();
 	const config = PRAYER_CONFIG[prayer];
+	const label =
+		i18n.language === 'en'
+			? config.labelEn
+			: i18n.language === 'ar'
+				? config.labelAr
+				: config.labelFr;
 	const progress =
 		debt.total_owed > 0 ? Math.min(100, (debt.total_completed / debt.total_owed) * 100) : 0;
 
@@ -23,12 +31,12 @@ export function PrayerCounter({ prayer, debt, onLog }: PrayerCounterProps) {
 					<div className="flex-1">
 						<div className="flex items-center gap-2">
 							<span className="text-base font-semibold" style={{ color: config.color }}>
-								{config.labelFr}
+								{label}
 							</span>
 							<span className="text-xs text-muted-foreground">{config.labelAr}</span>
 						</div>
 						<p className="mt-0.5 text-xs text-muted-foreground">
-							{debt.remaining.toLocaleString()} restantes
+							{t('dashboard.remaining', { count: debt.remaining })}
 						</p>
 						<Progress value={progress} className="mt-2 h-1.5" />
 					</div>
@@ -36,7 +44,7 @@ export function PrayerCounter({ prayer, debt, onLog }: PrayerCounterProps) {
 						size="icon"
 						onClick={() => onLog(prayer)}
 						disabled={debt.remaining === 0}
-						className="ml-4 h-10 w-10 shrink-0"
+						className="ms-4 h-10 w-10 shrink-0"
 					>
 						<Plus size={20} />
 					</Button>
@@ -53,15 +61,22 @@ interface PrayerRowProps {
 }
 
 export function PrayerRow({ prayer, quantity, onChange }: PrayerRowProps) {
+	const { i18n } = useTranslation();
 	const config = PRAYER_CONFIG[prayer];
+	const label =
+		i18n.language === 'en'
+			? config.labelEn
+			: i18n.language === 'ar'
+				? config.labelAr
+				: config.labelFr;
 
 	return (
 		<div className="flex items-center justify-between py-2">
 			<div>
 				<span className="font-medium" style={{ color: config.color }}>
-					{config.labelFr}
+					{label}
 				</span>
-				<span className="ml-2 text-xs text-muted-foreground">{config.labelAr}</span>
+				<span className="ms-2 text-xs text-muted-foreground">{config.labelAr}</span>
 			</div>
 			<div className="flex items-center gap-3">
 				<Button

--- a/src/components/PrayerCounter.tsx
+++ b/src/components/PrayerCounter.tsx
@@ -33,7 +33,9 @@ export function PrayerCounter({ prayer, debt, onLog }: PrayerCounterProps) {
 							<span className="text-base font-semibold" style={{ color: config.color }}>
 								{label}
 							</span>
-							<span className="text-xs text-muted-foreground">{config.labelAr}</span>
+							{i18n.language !== 'ar' && (
+								<span className="text-xs text-muted-foreground">{config.labelAr}</span>
+							)}
 						</div>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							{t('dashboard.remaining', { count: debt.remaining })}
@@ -76,7 +78,9 @@ export function PrayerRow({ prayer, quantity, onChange }: PrayerRowProps) {
 				<span className="font-medium" style={{ color: config.color }}>
 					{label}
 				</span>
-				<span className="ms-2 text-xs text-muted-foreground">{config.labelAr}</span>
+				{i18n.language !== 'ar' && (
+					<span className="ms-2 text-xs text-muted-foreground">{config.labelAr}</span>
+				)}
 			</div>
 			<div className="flex items-center gap-3">
 				<Button

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -46,8 +46,10 @@ function PrayerRow({
 	onChange: (p: PrayerName, q: number) => void;
 	index: number;
 }) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const cfg = PRAYER_CONFIG[prayer];
+	const label =
+		i18n.language === 'en' ? cfg.labelEn : i18n.language === 'ar' ? cfg.labelAr : cfg.labelFr;
 	const active = qty > 0;
 
 	return (
@@ -60,7 +62,7 @@ function PrayerRow({
 			<div className="flex items-center gap-3 px-5" style={{ height: 70 }}>
 				<div className="flex flex-1 flex-col gap-0.5">
 					<span className="font-display text-lg font-medium" style={{ color: cfg.hex }}>
-						{cfg.labelFr}
+						{label}
 					</span>
 					<span className="text-[11px]" style={{ color: '#4A4A4C' }}>
 						{cfg.labelAr} · {cfg.rakat} {t('log.rakat')}
@@ -435,6 +437,12 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 								>
 									{group.entries.map((log, li) => {
 										const cfg = PRAYER_CONFIG[log.prayer];
+										const entryLabel =
+											i18n.language === 'en'
+												? cfg.labelEn
+												: i18n.language === 'ar'
+													? cfg.labelAr
+													: cfg.labelFr;
 										const prevEntry = group.entries[li + 1];
 										const prayerDurationSec =
 											isSession && prevEntry
@@ -466,7 +474,7 @@ function HistoriqueTab({ logs, onUndo }: { logs: PrayerLog[]; onUndo: () => void
 															className="font-display text-[15px] font-medium"
 															style={{ color: cfg.hex }}
 														>
-															{cfg.labelFr}
+															{entryLabel}
 														</span>
 														<span className="text-xs" style={{ color: '#3A3A3C' }}>
 															{cfg.labelAr}

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -229,7 +229,7 @@ function DeleteEntrySheet({
 					<span className="text-base" style={{ color: `${cfg.hex}80` }}>
 						{cfg.labelAr}
 					</span>
-					<span className="ml-auto tabular-nums text-sm font-medium" style={{ color: '#6E6E70' }}>
+					<span className="ms-auto tabular-nums text-sm font-medium" style={{ color: '#6E6E70' }}>
 						+{log.quantity}
 					</span>
 				</div>
@@ -592,7 +592,7 @@ export function LogPrayers() {
 						</span>
 						{tab === 'history' && recentLogs.length > 0 && (
 							<motion.span
-								className="relative z-10 ml-1.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-semibold tabular-nums"
+								className="relative z-10 ms-1.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-semibold tabular-nums"
 								style={{
 									background: activeTab === tab ? '#1A1A1C30' : '#C9A96220',
 									color: activeTab === tab ? '#1A1A1C' : '#C9A962',

--- a/src/pages/Settings/SessionTab.tsx
+++ b/src/pages/Settings/SessionTab.tsx
@@ -110,7 +110,7 @@ export function SessionTab() {
 									</button>
 									<span className="min-w-[48px] text-center text-sm font-semibold tabular-nums text-foreground">
 										{Math.round(tashahdDurationMs / 1000)}
-										<span className="text-muted font-normal text-xs ml-0.5">s</span>
+										<span className="text-muted font-normal text-xs ms-0.5">s</span>
 									</span>
 									<button
 										type="button"


### PR DESCRIPTION
## Summary

- `ml-4` → `ms-4`, `ml-2` → `ms-2`, `ml-1.5` → `ms-1.5`, `ms-auto` in `PrayerCounter`, `InstallBanner`, `LogPrayers`
- `PrayerCounter`: use `i18n.language` to pick `labelFr/labelEn/labelAr` instead of always rendering French
- `PrayerCounter`: replace hardcoded `"restantes"` with `t('dashboard.remaining', { count })`

## Test plan

- [ ] In Arabic (`ar`), verify margins flip correctly (buttons appear on opposite side)
- [ ] In Arabic, verify prayer names show in Arabic in PrayerCounter and PrayerRow
- [ ] In English, verify prayer names show in English
- [ ] Counter shows correct translation (e.g. "5 remaining" / "5 restantes" / "٥ متبقية")

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prayer labels and counters now translate based on your active language setting.
  * "Remaining prayers" text is now localized to your preferred language.

* **Improvements**
  * Enhanced right-to-left (RTL) layout support with improved spacing logic.
  * Arabic label visibility is now correctly hidden when Arabic language mode is active.
  * Extended localization coverage for prayer-related interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->