### PR TITLE
fix(session): horizontal picker layout and proximity sensor grace period

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.31.0',
+		date: '2026-04-11',
+		changes: {
+			fr: [
+				'Session : boutons − et + déplacés à gauche et à droite du chiffre (layout horizontal) pour le sélecteur de nombre et le compteur de progression',
+				'Fix : soujoud détecté automatiquement au lancement de session corrigé — la période de grâce se réinitialise au démarrage réel de la caméra (après accord de permission)',
+			],
+			en: [
+				'Session: − and + buttons moved to left and right of the number (horizontal layout) for both the number picker and the progress counter',
+				'Fix: auto-detected sujood at session start corrected — grace period now resets when camera actually starts (after permission is granted)',
+			],
+		},
+	},
+	{
 		version: '1.30.0',
 		date: '2026-04-11',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -62,6 +62,7 @@ function NumberPicker({
 	dir: 1 | -1;
 	onChange: (v: number) => void;
 }) {
+	const { t } = useTranslation();
 	const accumulated = useRef(0);
 	const valueRef = useRef(value);
 	useEffect(() => {
@@ -86,6 +87,7 @@ function NumberPicker({
 		>
 			<motion.button
 				type="button"
+				aria-label={t('a11y.decrease')}
 				onClick={() => onChange(Math.max(1, value - 1))}
 				disabled={value <= 1}
 				className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
@@ -124,6 +126,7 @@ function NumberPicker({
 
 			<motion.button
 				type="button"
+				aria-label={t('a11y.increase')}
 				onClick={() => onChange(Math.min(MAX_PICKER_VALUE, value + 1))}
 				disabled={value >= MAX_PICKER_VALUE}
 				className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
@@ -171,6 +174,7 @@ function AnimatedCounter({
 	onDecrease?: () => void;
 	onIncrease?: () => void;
 }) {
+	const { t } = useTranslation();
 	const [display, setDisplay] = useState(value);
 	const prevRef = useRef(value);
 
@@ -202,6 +206,7 @@ function AnimatedCounter({
 			<div className="flex items-center gap-10 tabular-nums">
 				<motion.button
 					type="button"
+					aria-label={t('a11y.decrease')}
 					onClick={onDecrease}
 					disabled={!onDecrease}
 					className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
@@ -230,6 +235,7 @@ function AnimatedCounter({
 
 				<motion.button
 					type="button"
+					aria-label={t('a11y.increase')}
 					onClick={onIncrease}
 					disabled={!onIncrease}
 					className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, ChevronsUpDown, Timer } from 'lucide-react';
+import { CheckCircle2, Minus, Plus, Timer } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,16 +19,6 @@ type Phase = 'setup' | 'active' | 'complete';
 
 const pickerSpring = { type: 'spring' as const, stiffness: 320, damping: 38 };
 
-const ghostVariants = {
-	enter: (d: number) => ({ y: d > 0 ? 40 : -40, opacity: 0 }),
-	center: { y: 0, opacity: 0.25 },
-	exit: (d: number) => ({ y: d > 0 ? -40 : 40, opacity: 0 }),
-};
-const ghostStyle = {
-	color: 'var(--text-primary)',
-	fontSize: 42,
-	fontFamily: "ui-monospace, 'SF Mono', monospace",
-} as const;
 const MAX_PICKER_VALUE = 999;
 
 function RakatDots({ total, current, color }: { total: number; current: number; color: string }) {
@@ -63,42 +53,6 @@ function RakatDots({ total, current, color }: { total: number; current: number; 
 	);
 }
 
-function GhostButton({
-	show,
-	targetValue,
-	dir,
-	onChange,
-}: {
-	show: boolean;
-	targetValue: number;
-	dir: 1 | -1;
-	onChange: (v: number) => void;
-}) {
-	if (!show) return null;
-	return (
-		<div className="overflow-hidden flex items-center justify-center" style={{ height: 48 }}>
-			<AnimatePresence mode="popLayout" custom={dir}>
-				<motion.button
-					key={targetValue}
-					type="button"
-					custom={dir}
-					variants={ghostVariants}
-					initial="enter"
-					animate="center"
-					exit="exit"
-					transition={pickerSpring}
-					onClick={() => onChange(targetValue)}
-					className="tabular-nums leading-none"
-					style={ghostStyle}
-					whileTap={{ scale: 0.9 }}
-				>
-					{targetValue}
-				</motion.button>
-			</AnimatePresence>
-		</div>
-	);
-}
-
 function NumberPicker({
 	value,
 	dir,
@@ -116,7 +70,7 @@ function NumberPicker({
 
 	return (
 		<motion.div
-			className="flex flex-col items-center gap-1 py-2 cursor-ns-resize select-none touch-none"
+			className="flex items-center gap-5 py-2 cursor-ns-resize select-none touch-none"
 			onPan={(_, info) => {
 				accumulated.current -= info.delta.y;
 				const step = 10;
@@ -130,48 +84,55 @@ function NumberPicker({
 				accumulated.current = 0;
 			}}
 		>
-			<GhostButton show={value > 1} targetValue={value - 1} dir={dir} onChange={onChange} />
+			<motion.button
+				type="button"
+				onClick={() => onChange(Math.max(1, value - 1))}
+				disabled={value <= 1}
+				className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
+				whileTap={{ scale: 0.88 }}
+				whileHover={{ scale: 1.06 }}
+				transition={spring}
+			>
+				<Minus size={22} style={{ color: 'var(--gold)' }} />
+			</motion.button>
 
-			<div className="flex items-center gap-3">
-				<div className="overflow-hidden flex items-center" style={{ height: 88 }}>
-					<AnimatePresence mode="popLayout" custom={dir}>
-						<motion.span
-							key={value}
-							custom={dir}
-							variants={{
-								enter: (d: number) => ({ y: d > 0 ? 48 : -48, opacity: 0, scale: 0.85 }),
-								center: { y: 0, opacity: 1, scale: 1 },
-								exit: (d: number) => ({ y: d > 0 ? -48 : 48, opacity: 0, scale: 0.85 }),
-							}}
-							initial="enter"
-							animate="center"
-							exit="exit"
-							transition={pickerSpring}
-							className="tabular-nums leading-none"
-							style={{
-								color: 'var(--text-primary)',
-								fontSize: 76,
-								fontFamily: "ui-monospace, 'SF Mono', monospace",
-							}}
-						>
-							{value}
-						</motion.span>
-					</AnimatePresence>
-				</div>
-				<motion.div
-					animate={{ opacity: [0.3, 0.7, 0.3] }}
-					transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
-				>
-					<ChevronsUpDown size={22} style={{ color: 'var(--text-tertiary)' }} />
-				</motion.div>
+			<div className="overflow-hidden flex items-center" style={{ height: 88, minWidth: 72 }}>
+				<AnimatePresence mode="popLayout" custom={dir}>
+					<motion.span
+						key={value}
+						custom={dir}
+						variants={{
+							enter: (d: number) => ({ y: d > 0 ? 48 : -48, opacity: 0, scale: 0.85 }),
+							center: { y: 0, opacity: 1, scale: 1 },
+							exit: (d: number) => ({ y: d > 0 ? -48 : 48, opacity: 0, scale: 0.85 }),
+						}}
+						initial="enter"
+						animate="center"
+						exit="exit"
+						transition={pickerSpring}
+						className="tabular-nums leading-none w-full text-center"
+						style={{
+							color: 'var(--text-primary)',
+							fontSize: 76,
+							fontFamily: "ui-monospace, 'SF Mono', monospace",
+						}}
+					>
+						{value}
+					</motion.span>
+				</AnimatePresence>
 			</div>
 
-			<GhostButton
-				show={value < MAX_PICKER_VALUE}
-				targetValue={value + 1}
-				dir={dir}
-				onChange={onChange}
-			/>
+			<motion.button
+				type="button"
+				onClick={() => onChange(Math.min(MAX_PICKER_VALUE, value + 1))}
+				disabled={value >= MAX_PICKER_VALUE}
+				className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
+				whileTap={{ scale: 0.88 }}
+				whileHover={{ scale: 1.06 }}
+				transition={spring}
+			>
+				<Plus size={22} style={{ color: 'var(--gold)' }} />
+			</motion.button>
 		</motion.div>
 	);
 }
@@ -238,48 +199,46 @@ function AnimatedCounter({
 
 	return (
 		<div className="flex flex-col items-center gap-4 w-full">
-			<div className="flex items-end gap-1 tabular-nums">
-				<motion.span
-					key={display}
-					className="text-[72px] font-light leading-none"
-					style={{ color: 'var(--text-primary)' }}
-					initial={{ opacity: 0.5, y: 8 }}
-					animate={{ opacity: 1, y: 0 }}
+			<div className="flex items-center gap-10 tabular-nums">
+				<motion.button
+					type="button"
+					onClick={onDecrease}
+					disabled={!onDecrease}
+					className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
+					whileTap={{ scale: 0.88 }}
+					whileHover={{ scale: 1.06 }}
 					transition={spring}
 				>
-					{display}
-				</motion.span>
-				<div className="flex flex-col items-center gap-1 mb-2">
-					{onIncrease && (
-						<button
-							type="button"
-							onClick={onIncrease}
-							className="flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium transition-opacity active:opacity-60"
-							style={{
-								color: 'var(--gold)',
-								background: 'color-mix(in srgb, var(--gold) 12%, transparent)',
-							}}
-						>
-							+
-						</button>
-					)}
-					<span className="text-2xl font-light" style={{ color: 'var(--text-tertiary)' }}>
+					<Minus size={22} style={{ color: 'var(--gold)' }} />
+				</motion.button>
+
+				<div className="flex items-end gap-2">
+					<motion.span
+						key={display}
+						className="text-[72px] font-light leading-none"
+						style={{ color: 'var(--text-primary)' }}
+						initial={{ opacity: 0.5, y: 8 }}
+						animate={{ opacity: 1, y: 0 }}
+						transition={spring}
+					>
+						{display}
+					</motion.span>
+					<span className="text-2xl font-light mb-2" style={{ color: 'var(--text-tertiary)' }}>
 						/ {target}
 					</span>
-					{onDecrease && (
-						<button
-							type="button"
-							onClick={onDecrease}
-							className="flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium transition-opacity active:opacity-60"
-							style={{
-								color: 'var(--gold)',
-								background: 'color-mix(in srgb, var(--gold) 12%, transparent)',
-							}}
-						>
-							−
-						</button>
-					)}
 				</div>
+
+				<motion.button
+					type="button"
+					onClick={onIncrease}
+					disabled={!onIncrease}
+					className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-surface disabled:opacity-30"
+					whileTap={{ scale: 0.88 }}
+					whileHover={{ scale: 1.06 }}
+					transition={spring}
+				>
+					<Plus size={22} style={{ color: 'var(--gold)' }} />
+				</motion.button>
 			</div>
 
 			{/* Progress bar */}
@@ -657,7 +616,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 						</motion.div>
 
 						<motion.div
-							className="mb-6"
+							className="my-14 flex flex-col items-center"
 							initial={{ opacity: 0, y: 16 }}
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ delay: 0.18, ...spring }}

--- a/src/hooks/useProximitySensor.test.ts
+++ b/src/hooks/useProximitySensor.test.ts
@@ -60,6 +60,7 @@ describe('useProximitySensor', () => {
 			const onFirst = vi.fn();
 			const { result } = renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchProximity(1));
 
 			expect(result.current.currentState).toBe('waiting_second');
@@ -70,8 +71,9 @@ describe('useProximitySensor', () => {
 			const onSecond = vi.fn();
 			const { result } = renderHook(() => useProximitySensor(true, vi.fn(), onSecond));
 
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchProximity(1));
-			vi.setSystemTime(PINNED_NOW + 1000);
+			vi.setSystemTime(PINNED_NOW + 2500);
 			act(() => dispatchProximity(1));
 
 			expect(result.current.currentState).toBe('waiting_first');
@@ -91,8 +93,9 @@ describe('useProximitySensor', () => {
 			const onFirst = vi.fn();
 			const { result } = renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchProximity(1));
-			vi.setSystemTime(PINNED_NOW + 500);
+			vi.setSystemTime(PINNED_NOW + 2000);
 			act(() => dispatchProximity(1));
 
 			expect(onFirst).toHaveBeenCalledOnce();
@@ -103,8 +106,9 @@ describe('useProximitySensor', () => {
 			const onFirst = vi.fn();
 			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchProximity(1));
-			vi.setSystemTime(PINNED_NOW + 900);
+			vi.setSystemTime(PINNED_NOW + 2400);
 			act(() => dispatchProximity(1));
 
 			// First event → waiting_second, second near event → onSecond (not onFirst again)
@@ -182,8 +186,9 @@ describe('useProximitySensor', () => {
 			const { result } = renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
 			act(() => dispatchOrientation(10)); // baseline = 10
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchOrientation(65)); // delta = 55 > 50 → sujood down
-			vi.setSystemTime(PINNED_NOW + 400);
+			vi.setSystemTime(PINNED_NOW + 1900);
 			act(() => dispatchOrientation(12)); // delta = 2 < 25 && elapsed 400ms ≥ 300 → sujood up
 
 			expect(onFirst).toHaveBeenCalledOnce();
@@ -210,12 +215,13 @@ describe('useProximitySensor', () => {
 			const { result } = renderHook(() => useProximitySensor(true, onFirst, onSecond));
 
 			act(() => dispatchOrientation(10)); // baseline
+			vi.setSystemTime(PINNED_NOW + 1500);
 			act(() => dispatchOrientation(65)); // down 1
-			vi.setSystemTime(PINNED_NOW + 400);
+			vi.setSystemTime(PINNED_NOW + 1900);
 			act(() => dispatchOrientation(12)); // up 1 → onFirst
-			vi.setSystemTime(PINNED_NOW + 1300);
+			vi.setSystemTime(PINNED_NOW + 2800);
 			act(() => dispatchOrientation(65)); // down 2
-			vi.setSystemTime(PINNED_NOW + 1700);
+			vi.setSystemTime(PINNED_NOW + 3200);
 			act(() => dispatchOrientation(12)); // up 2 → onSecond
 
 			expect(onFirst).toHaveBeenCalledOnce();
@@ -343,11 +349,12 @@ describe('useProximitySensor', () => {
 				await Promise.resolve();
 			});
 
+			act(() => vi.advanceTimersByTime(1500)); // advance past 1500ms grace period
 			pixelData.fill(0);
-			act(() => vi.advanceTimersByTime(200)); // tick 1 at +200ms: dark → coveredSinceMs = PINNED_NOW+200
-			act(() => vi.advanceTimersByTime(200)); // tick 2 at +400ms: dark
+			act(() => vi.advanceTimersByTime(200)); // tick: dark → coveredSinceMs set
+			act(() => vi.advanceTimersByTime(200)); // tick: dark
 			pixelData.fill(200);
-			act(() => vi.advanceTimersByTime(200)); // tick 3 at +600ms: bright, elapsed=400ms → fires
+			act(() => vi.advanceTimersByTime(200)); // tick: bright, elapsed=400ms → fires
 
 			expect(onFirst).toHaveBeenCalledOnce();
 			expect(result.current.currentState).toBe('waiting_second');
@@ -377,8 +384,9 @@ describe('useProximitySensor', () => {
 				await Promise.resolve();
 			});
 
+			act(() => vi.advanceTimersByTime(1500)); // advance past 1500ms grace period
 			pixelData.fill(0);
-			act(() => vi.advanceTimersByTime(200)); // dark → coveredSinceMs set at PINNED_NOW+200
+			act(() => vi.advanceTimersByTime(200)); // dark → coveredSinceMs set
 			act(() => vi.advanceTimersByTime(5200)); // advance 5200ms (elapsed > 5000ms max)
 			pixelData.fill(200);
 			act(() => vi.advanceTimersByTime(200)); // bright, but elapsed > 5000ms → no callback
@@ -395,6 +403,7 @@ describe('useProximitySensor', () => {
 				await Promise.resolve();
 			});
 
+			act(() => vi.advanceTimersByTime(1500)); // advance past 1500ms grace period
 			pixelData.fill(0);
 			act(() => vi.advanceTimersByTime(200)); // dark
 			act(() => vi.advanceTimersByTime(200)); // dark

--- a/src/hooks/useProximitySensor.test.ts
+++ b/src/hooks/useProximitySensor.test.ts
@@ -201,8 +201,9 @@ describe('useProximitySensor', () => {
 			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
 			act(() => dispatchOrientation(10)); // baseline = 10
-			act(() => dispatchOrientation(65)); // delta = 55 → down (at PINNED_NOW)
-			vi.setSystemTime(PINNED_NOW + 200);
+			vi.setSystemTime(PINNED_NOW + 1500);
+			act(() => dispatchOrientation(65)); // delta = 55 → down (past grace period)
+			vi.setSystemTime(PINNED_NOW + 1700);
 			act(() => dispatchOrientation(12)); // delta = 2 < 25 but elapsed 200ms < 300 → ignored
 
 			expect(onFirst).not.toHaveBeenCalled();
@@ -267,16 +268,17 @@ describe('useProximitySensor', () => {
 			renderHook(() => useProximitySensor(true, onFirst, vi.fn()));
 
 			act(() => dispatchOrientation(10)); // baseline = 10
-			act(() => dispatchOrientation(65)); // delta = 55 → sujood down at PINNED_NOW
-			vi.setSystemTime(PINNED_NOW + 5001);
+			vi.setSystemTime(PINNED_NOW + 1500);
+			act(() => dispatchOrientation(65)); // delta = 55 → sujood down (past grace period)
+			vi.setSystemTime(PINNED_NOW + 6501);
 			act(() => dispatchOrientation(12)); // elapsed > 5000 → reset, no callback
 
 			expect(onFirst).not.toHaveBeenCalled();
 
 			// A fresh sujood sequence now works
 			act(() => dispatchOrientation(65)); // delta = 55 → new sujood down
-			vi.setSystemTime(PINNED_NOW + 5500);
-			act(() => dispatchOrientation(12)); // delta = 2 < 25, elapsed 499ms → fires
+			vi.setSystemTime(PINNED_NOW + 6900);
+			act(() => dispatchOrientation(12)); // delta = 2 < 25, elapsed 399ms → fires
 
 			expect(onFirst).toHaveBeenCalledOnce();
 		});

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -30,6 +30,7 @@ export function useProximitySensor(
 	const [currentState, setCurrentState] = useState<SensorState>('idle');
 	const sensorRef = useRef<any>(null);
 	const lastDetectionRef = useRef<number>(0);
+	const ignoreUntilRef = useRef<number>(0);
 	const sujoodCountRef = useRef<0 | 1>(0);
 	const callbacksRef = useRef({ onFirstSujood, onSecondSujood });
 	const betaBaselineRef = useRef<number | null>(null);
@@ -62,6 +63,7 @@ export function useProximitySensor(
 
 		setCurrentState('waiting_first');
 		lastDetectionRef.current = 0;
+		ignoreUntilRef.current = Date.now() + 1500;
 		sujoodCountRef.current = 0;
 		betaBaselineRef.current = null;
 		sujoodDownTimeRef.current = 0;
@@ -71,6 +73,7 @@ export function useProximitySensor(
 			if (!isNear || cancelled) return;
 
 			const now = Date.now();
+			if (now < ignoreUntilRef.current) return;
 			if (now - lastDetectionRef.current < DEBOUNCE_MS) return;
 			lastDetectionRef.current = now;
 
@@ -171,7 +174,7 @@ export function useProximitySensor(
 				const delta = Math.abs(event.beta - betaBaselineRef.current);
 
 				if (sujoodDownTimeRef.current === 0) {
-					if (delta > TILT_DOWN_THRESHOLD) {
+					if (delta > TILT_DOWN_THRESHOLD && Date.now() >= ignoreUntilRef.current) {
 						sujoodDownTimeRef.current = Date.now();
 					}
 				} else {
@@ -208,6 +211,8 @@ export function useProximitySensor(
 						for (const t of stream.getTracks()) t.stop();
 						return;
 					}
+					// Camera may start long after the effect (e.g. permission dialog) — reset grace period
+					ignoreUntilRef.current = Date.now() + 1500;
 					const video = document.createElement('video');
 					video.muted = true;
 					video.srcObject = stream;
@@ -219,6 +224,7 @@ export function useProximitySensor(
 					if (!ctx) {
 						for (const t of stream.getTracks()) t.stop();
 						if (!cancelled) {
+							ignoreUntilRef.current = Date.now() + 1500;
 							orientationTimerCleanup = setupDeviceOrientationFallback();
 						}
 						return;
@@ -237,7 +243,11 @@ export function useProximitySensor(
 								sum += (data[i] + data[i + 1] + data[i + 2]) / 3;
 							}
 							const avg = sum / (CAMERA_WIDTH * CAMERA_HEIGHT);
-							if (coveredSinceMs === 0 && avg < CAMERA_DARK_THRESHOLD) {
+							if (
+								coveredSinceMs === 0 &&
+								avg < CAMERA_DARK_THRESHOLD &&
+								Date.now() >= ignoreUntilRef.current
+							) {
 								coveredSinceMs = Date.now();
 							} else if (coveredSinceMs > 0 && avg > CAMERA_LIGHT_THRESHOLD) {
 								const elapsed = Date.now() - coveredSinceMs;
@@ -257,6 +267,7 @@ export function useProximitySensor(
 					};
 				} catch {
 					if (!cancelled) {
+						ignoreUntilRef.current = Date.now() + 1500;
 						orientationTimerCleanup = setupDeviceOrientationFallback();
 					}
 				}

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -20,6 +20,7 @@ const CAMERA_HEIGHT = 60;
 const CAMERA_INTERVAL_MS = 200;
 const CAMERA_DARK_THRESHOLD = 25;
 const CAMERA_LIGHT_THRESHOLD = 50;
+const STARTUP_GRACE_MS = 1500;
 
 export function useProximitySensor(
 	active: boolean,
@@ -63,7 +64,7 @@ export function useProximitySensor(
 
 		setCurrentState('waiting_first');
 		lastDetectionRef.current = 0;
-		ignoreUntilRef.current = Date.now() + 1500;
+		ignoreUntilRef.current = Date.now() + STARTUP_GRACE_MS;
 		sujoodCountRef.current = 0;
 		betaBaselineRef.current = null;
 		sujoodDownTimeRef.current = 0;
@@ -212,7 +213,7 @@ export function useProximitySensor(
 						return;
 					}
 					// Camera may start long after the effect (e.g. permission dialog) — reset grace period
-					ignoreUntilRef.current = Date.now() + 1500;
+					ignoreUntilRef.current = Date.now() + STARTUP_GRACE_MS;
 					const video = document.createElement('video');
 					video.muted = true;
 					video.srcObject = stream;
@@ -224,7 +225,7 @@ export function useProximitySensor(
 					if (!ctx) {
 						for (const t of stream.getTracks()) t.stop();
 						if (!cancelled) {
-							ignoreUntilRef.current = Date.now() + 1500;
+							ignoreUntilRef.current = Date.now() + STARTUP_GRACE_MS;
 							orientationTimerCleanup = setupDeviceOrientationFallback();
 						}
 						return;
@@ -267,7 +268,7 @@ export function useProximitySensor(
 					};
 				} catch {
 					if (!cancelled) {
-						ignoreUntilRef.current = Date.now() + 1500;
+						ignoreUntilRef.current = Date.now() + STARTUP_GRACE_MS;
 						orientationTimerCleanup = setupDeviceOrientationFallback();
 					}
 				}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -244,5 +244,9 @@
 		"title": "Keep it up!",
 		"subtitle": "{{count}} prayers made up",
 		"close": "Continue"
+	},
+	"a11y": {
+		"decrease": "Decrease",
+		"increase": "Increase"
 	}
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -244,5 +244,9 @@
 		"title": "Bravo, continue ainsi !",
 		"subtitle": "{{count}} prières rattrapées",
 		"close": "Continuer"
+	},
+	"a11y": {
+		"decrease": "Diminuer",
+		"increase": "Augmenter"
 	}
 }


### PR DESCRIPTION
## Summary

- **Session picker/counter**: replaced vertical ghost-button layout with horizontal `− number +` layout for both the number picker and progress counter — simpler, more intuitive touch targets
- **Proximity sensor**: added 1500ms grace period (`ignoreUntilRef`) that resets at session start, camera permission grant, and orientation fallback — prevents false sujood detection on launch
- **Tests**: updated all 9 affected proximity sensor tests to advance past the grace period before asserting detection behavior

## Test plan

- [x] All 152 tests pass locally (`pnpm test:run`)
- [ ] Verify horizontal `−` / `+` buttons work correctly in session picker (number selection)
- [ ] Verify horizontal `−` / `+` buttons work in progress counter during active session
- [ ] Confirm no false sujood detection at session start on mobile (camera path)
- [ ] Confirm sujood detection still works after the 1.5s grace period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added changelog entry for version 1.31.0 with localized descriptions.

* **Improvements**
  * Updated session setup controls and layout for clearer increment/decrement interaction.
  * Introduced a startup grace window to improve proximity/orientation/camera detection reliability.
  * Added accessibility labels for increase/decrease controls (English and French).

* **Tests**
  * Adjusted proximity sensor tests to reflect new timing/grace-period behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->