### PR TITLE
refactor: use calculateProgress everywhere — PrayerCounter + ObjectiveTracker

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,14 +10,16 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
-		version: '1.30.2',
+		version: '1.30.3',
 		date: '2026-04-13',
 		changes: {
 			fr: [
 				'Mise à jour de toutes les dépendances : Vite 8, TypeScript 6, Lucide React 1.x, i18next 26, react-i18next 17, Dexie 4.4, Vitest 4.1.4',
+				'Simplification : calculateProgress() maintenant utilisé dans PrayerCounter et ObjectiveTracker — formule centralisée en un seul endroit',
 			],
 			en: [
 				'All dependencies updated: Vite 8, TypeScript 6, Lucide React 1.x, i18next 26, react-i18next 17, Dexie 4.4, Vitest 4.1.4',
+				'Simplify: calculateProgress() now used in PrayerCounter and ObjectiveTracker — formula centralized in one place',
 			],
 		},
 	},

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,7 +10,7 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
-		version: '1.30.3',
+		version: '1.30.2',
 		date: '2026-04-13',
 		changes: {
 			fr: [

--- a/src/components/ObjectiveTracker.tsx
+++ b/src/components/ObjectiveTracker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
+import { calculateProgress } from '@/lib/progress';
 import type { Objective, StatsState } from '@/types';
 
 interface ObjectiveTrackerProps {
@@ -19,7 +20,7 @@ const PERIOD_VALUE = (stats: StatsState, period: string): number => {
 export function ObjectiveTracker({ objective, stats }: ObjectiveTrackerProps) {
 	const { t } = useTranslation();
 	const current = PERIOD_VALUE(stats, objective.period);
-	const progress = objective.target > 0 ? Math.min(100, (current / objective.target) * 100) : 0;
+	const progress = calculateProgress(current, objective.target);
 	const done = current >= objective.target;
 	const periodLabel = t(`objective.periodLabel_${objective.period}`);
 

--- a/src/components/PrayerCounter.tsx
+++ b/src/components/PrayerCounter.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { getPrayerLabel, PRAYER_CONFIG } from '@/constants/prayers';
+import { calculateProgress } from '@/lib/progress';
 import type { PrayerDebt, PrayerName } from '@/types';
 
 interface PrayerCounterProps {
@@ -16,8 +17,7 @@ export function PrayerCounter({ prayer, debt, onLog }: PrayerCounterProps) {
 	const { t, i18n } = useTranslation();
 	const config = PRAYER_CONFIG[prayer];
 	const label = getPrayerLabel(config, i18n.language);
-	const progress =
-		debt.total_owed > 0 ? Math.min(100, (debt.total_completed / debt.total_owed) * 100) : 0;
+	const progress = calculateProgress(debt.total_completed, debt.total_owed);
 
 	return (
 		<Card className="border-border bg-card">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -69,7 +69,9 @@ function PrayerRow({
 			if (!shouldReduce) {
 				setJustLogged(true);
 			}
-		} catch {}
+		} catch (err) {
+			if (import.meta.env.DEV) console.error('logPrayer failed', err);
+		}
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- `PrayerCounter` and `ObjectiveTracker` were still inlining the same `Math.min(100, (x/y)*100)` formula that was centralized in `calculateProgress()` in the previous PR — migrated both
- Restored dev-only error logging in the `handleLog` catch block (was silently swallowed)

## Test plan
- [ ] Build passes
- [ ] All 152 tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated progress calculation logic into a shared helper function used across Prayer Counter and Objective Tracker components, eliminating code duplication and improving maintainability.

* **Documentation**
  * Updated changelog for version 1.30.2 documenting the centralized progress calculation implementation.

* **Chores**
  * Enhanced error reporting for prayer logging operations when running in development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->