### PR TITLE
fix: show toast on logPrayer failure

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,16 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.4',
+		date: '2026-04-15',
+		changes: {
+			fr: [
+				"Fix : erreur toast affichée si la sauvegarde d'une prière échoue (quota dépassé, DB inaccessible)",
+			],
+			en: ['Fix: toast error shown if saving a prayer fails (quota exceeded, DB unavailable)'],
+		},
+	},
+	{
 		version: '1.30.2',
 		date: '2026-04-13',
 		changes: {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { MessageSquare, Plus, RotateCcw, Share2 } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { EstimationCard } from '@/components/EstimationCard';
 import { FeedbackModal } from '@/components/FeedbackModal';
 import { Session } from '@/components/Session';
@@ -69,8 +70,8 @@ function PrayerRow({
 			if (!shouldReduce) {
 				setJustLogged(true);
 			}
-		} catch (err) {
-			if (import.meta.env.DEV) console.error('logPrayer failed', err);
+		} catch {
+			toast.error(t('common.error'));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `handleLog` catch block was DEV-only (`import.meta.env.DEV`), so Dexie write failures (quota exceeded, DB locked) silently vanished in production
- Replaced with `toast.error(t('common.error'))` — user sees feedback on failure in all environments

## Test plan
- [ ] Build passes, 152 tests green
- [ ] Normal prayer logging still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated changelog with version 1.30.4 release information, available in both English and French localization.

* **Bug Fixes**
  * Improved error feedback for prayer logging functionality with enhanced user-facing error notifications, providing clearer communication when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->