### PR TITLE
fix: restore dev console.error alongside toast on logPrayer failure

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.5',
+		date: '2026-04-15',
+		changes: {
+			fr: ["Fix : log d'erreur en développement restauré sur les échecs de sauvegarde de prière"],
+			en: ['Fix: dev error log restored on prayer save failures'],
+		},
+	},
+	{
 		version: '1.30.4',
 		date: '2026-04-15',
 		changes: {

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,21 +10,17 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
-		version: '1.30.5',
-		date: '2026-04-15',
-		changes: {
-			fr: ["Fix : log d'erreur en développement restauré sur les échecs de sauvegarde de prière"],
-			en: ['Fix: dev error log restored on prayer save failures'],
-		},
-	},
-	{
 		version: '1.30.4',
 		date: '2026-04-15',
 		changes: {
 			fr: [
 				"Fix : erreur toast affichée si la sauvegarde d'une prière échoue (quota dépassé, DB inaccessible)",
+				"Fix : log d'erreur en développement restauré sur les échecs de sauvegarde de prière",
 			],
-			en: ['Fix: toast error shown if saving a prayer fails (quota exceeded, DB unavailable)'],
+			en: [
+				'Fix: toast error shown if saving a prayer fails (quota exceeded, DB unavailable)',
+				'Fix: dev error log restored on prayer save failures',
+			],
 		},
 	},
 	{

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -70,7 +70,8 @@ function PrayerRow({
 			if (!shouldReduce) {
 				setJustLogged(true);
 			}
-		} catch {
+		} catch (err) {
+			if (import.meta.env.DEV) console.error('logPrayer failed', err);
 			toast.error(t('common.error'));
 		}
 	}


### PR DESCRIPTION
## Summary
- The previous PR replaced `if (import.meta.env.DEV) console.error(...)` with just `toast.error` — removing the dev debugging signal
- Restored: `catch (err)` now logs in dev AND shows the toast, so both concerns are covered

## Test plan
- [ ] Build passes, 152 tests green