### PR TITLE
chore(ci): group dependabot updates + add github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,23 @@ updates:
       - "mkldevops"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+      major:
+        update-types:
+          - "major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    assignees:
+      - "mkldevops"
+    commit-message:
+      prefix: "chore(ci)"

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,18 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.5',
+		date: '2026-04-15',
+		changes: {
+			fr: [
+				'CI : Dependabot configuré avec grouping (patch/minor en une PR, major séparés) et surveillance des GitHub Actions',
+			],
+			en: [
+				'CI: Dependabot configured with grouping (patch/minor in one PR, majors separate) and GitHub Actions ecosystem added',
+			],
+		},
+	},
+	{
 		version: '1.30.4',
 		date: '2026-04-15',
 		changes: {


### PR DESCRIPTION
## Summary
- **Grouped updates**: patch + minor into one PR per week, majors in a separate PR — instead of 14 individual PRs
- **GitHub Actions ecosystem** added so `release.yml` action versions are also kept up to date

## Before → After
- Before: up to 14 separate Dependabot PRs per week
- After: max 2 PRs (1 patch/minor bundle + 1 major bundle if any)