### PR TITLE
chore(ci): auto-merge Dependabot patch/minor PRs when CI passes

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-approve and merge patch/minor
+        if: |
+          contains(
+            fromJSON('["version-update:semver-patch","version-update:semver-minor"]'),
+            steps.metadata.outputs.update-type
+          )
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,18 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.6',
+		date: '2026-04-15',
+		changes: {
+			fr: [
+				'CI : auto-merge Dependabot activé — les mises à jour patch/minor sont fusionnées automatiquement quand le CI est vert',
+			],
+			en: [
+				'CI: Dependabot auto-merge enabled — patch/minor updates are merged automatically when CI passes',
+			],
+		},
+	},
+	{
 		version: '1.30.5',
 		date: '2026-04-15',
 		changes: {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-automerge.yml`
- Triggers on `pull_request_target` from `dependabot[bot]` (write permissions via base branch context)
- **patch + minor** → auto-approved + auto-merged (squash) when CI is green
- **major** → left open for manual review

`allow_auto_merge` was already enabled on the repo.