### PR TITLE
refactor(ui): replace remaining hardcoded colors, magic numbers, and any types

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,22 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.7',
+		date: '2026-04-15',
+		changes: {
+			fr: [
+				'Refactor : remplacement des couleurs hardcodées restantes par les tokens du design system (Settings, InstallBanner, overlays)',
+				'Refactor : typage strict des entrées de sauvegarde (PrayerLog / PrayerDebt / Objective) — suppression des `any`',
+				'Refactor : nombre magique de hauteur de ligne de prière remplacé par une classe Tailwind canonique',
+			],
+			en: [
+				'Refactor: replaced remaining hardcoded colors with design system tokens (Settings, InstallBanner, overlays)',
+				'Refactor: strictly typed backup imports (PrayerLog / PrayerDebt / Objective) — removed `any`',
+				'Refactor: prayer row height magic number replaced with a canonical Tailwind class',
+			],
+		},
+	},
+	{
 		version: '1.30.6',
 		date: '2026-04-15',
 		changes: {

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -41,30 +41,17 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 			exit={{ opacity: 0, y: 8 }}
 			transition={{ type: 'spring', stiffness: 400, damping: 30 }}
 		>
-			<div
-				className="rounded-2xl px-5 py-4 flex items-center justify-between"
-				style={{
-					background: '#242426',
-					border: '1px solid #3A3A3C',
-					color: '#F5F5F0',
-				}}
-			>
+			<div className="rounded-2xl px-5 py-4 flex items-center justify-between bg-surface border border-border text-foreground">
 				<div className="flex flex-col gap-1 flex-1">
 					<span className="text-sm font-semibold">{t('installBanner.title')}</span>
-					<span className="text-xs" style={{ color: '#6E6E70' }}>
-						{t('installBanner.subtitle')}
-					</span>
+					<span className="text-xs text-muted">{t('installBanner.subtitle')}</span>
 				</div>
 				<div className="flex gap-2 ms-4">
 					<button
 						type="button"
 						onClick={handleInstall}
 						disabled={isPrompting}
-						className="px-4 py-2 rounded-2xl text-sm font-medium whitespace-nowrap disabled:opacity-50 transition-opacity"
-						style={{
-							background: 'linear-gradient(135deg, #C9A962, #8B7845)',
-							color: '#1A1A1C',
-						}}
+						className="px-4 py-2 rounded-2xl text-sm font-medium whitespace-nowrap disabled:opacity-50 transition-opacity gradient-gold text-background"
 					>
 						{isPrompting ? '...' : t('installBanner.install')}
 					</button>
@@ -72,11 +59,7 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 						type="button"
 						onClick={handleDismiss}
 						disabled={isPrompting}
-						className="px-4 py-2 rounded-2xl text-sm font-medium disabled:opacity-50 transition-opacity"
-						style={{
-							background: '#3A3A3C',
-							color: '#F5F5F0',
-						}}
+						className="px-4 py-2 rounded-2xl text-sm font-medium disabled:opacity-50 transition-opacity bg-surface-raised text-foreground"
 					>
 						{t('installBanner.later')}
 					</button>

--- a/src/components/MilestoneModal.tsx
+++ b/src/components/MilestoneModal.tsx
@@ -38,8 +38,7 @@ function MilestoneContent({ milestone, onClose }: { milestone: Milestone; onClos
 			animate={{ opacity: 1 }}
 			exit={{ opacity: 0 }}
 			transition={{ duration: 0.2 }}
-			className="fixed inset-0 z-50 flex items-center justify-center"
-			style={{ background: 'rgba(26, 26, 28, 0.9)' }}
+			className="fixed inset-0 z-50 flex items-center justify-center bg-background/90"
 			onClick={onClose}
 		>
 			<motion.div

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -356,14 +356,14 @@ export async function importBackup(
 
 		// Import logs
 		if (data.prayer_logs.length > 0) {
-			const logsToAdd = data.prayer_logs.map(({ id: _, ...r }: any) => r);
+			const logsToAdd = data.prayer_logs.map(({ id: _, ...r }: PrayerLog) => r);
 			await db.prayer_logs.bulkAdd(logsToAdd);
 		}
 
 		// Import debts
 		const importedPrayers = new Set<PrayerName>();
 		if (data.prayer_debts.length > 0) {
-			const debtsToAdd = data.prayer_debts.map(({ id: _, ...r }: any) => {
+			const debtsToAdd = data.prayer_debts.map(({ id: _, ...r }: PrayerDebt) => {
 				importedPrayers.add(r.prayer);
 				return r;
 			});
@@ -386,7 +386,7 @@ export async function importBackup(
 
 		// Import objectives
 		if (data.objectives.length > 0) {
-			const objToAdd = data.objectives.map(({ id: _, ...r }: any) => r);
+			const objToAdd = data.objectives.map(({ id: _, ...r }: Objective) => r);
 			await db.objectives.bulkAdd(objToAdd);
 		}
 	});

--- a/src/hooks/useProximitySensor.ts
+++ b/src/hooks/useProximitySensor.ts
@@ -29,6 +29,7 @@ export function useProximitySensor(
 ): UseProximitySensorResult {
 	const [isSupported, setIsSupported] = useState(false);
 	const [currentState, setCurrentState] = useState<SensorState>('idle');
+	// biome-ignore lint/suspicious/noExplicitAny: heterogeneous sensor ref (ProximitySensor API, event handlers, camera cleanup) — non-standard browser APIs
 	const sensorRef = useRef<any>(null);
 	const lastDetectionRef = useRef<number>(0);
 	const ignoreUntilRef = useRef<number>(0);
@@ -135,6 +136,7 @@ export function useProximitySensor(
 
 		// Fallback to deviceproximity event (Firefox, Android)
 		function setupDeviceProximityFallback() {
+			// biome-ignore lint/suspicious/noExplicitAny: non-standard Firefox DeviceProximityEvent has no TypeScript types
 			function handleDeviceProximity(event: any) {
 				const isNear = (event.value as number) < 5;
 				handleProximityDetection(isNear);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -78,8 +78,7 @@ function PrayerRow({
 
 	return (
 		<motion.div
-			className="relative flex items-center gap-4 overflow-hidden rounded-2xl bg-surface border border-border px-5"
-			style={{ height: 72 }}
+			className="relative flex items-center gap-4 overflow-hidden rounded-2xl bg-surface border border-border px-5 h-18"
 			initial={{ opacity: 0, x: -16 }}
 			animate={{ opacity: 1, x: 0 }}
 			transition={{ delay: 0.22 + index * 0.05, ...spring }}

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -205,8 +205,7 @@ function DeleteEntrySheet({
 	return (
 		<>
 			<motion.div
-				className="fixed inset-0 z-[60]"
-				style={{ background: 'rgba(0,0,0,0.6)' }}
+				className="fixed inset-0 z-[60] bg-black/60"
 				initial={{ opacity: 0 }}
 				animate={{ opacity: 1 }}
 				exit={{ opacity: 0 }}

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -36,25 +36,15 @@ export function Settings({ onRestartOnboarding }: { onRestartOnboarding?: () => 
 
 	return (
 		<div className="flex flex-col gap-5 px-7 pb-4 pt-1">
-			<h1 className="font-display text-3xl font-normal" style={{ color: '#F5F5F0' }}>
-				{t('settings.title')}
-			</h1>
+			<h1 className="font-display text-3xl font-normal text-foreground">{t('settings.title')}</h1>
 
-			<div
-				className="flex gap-1 rounded-[20px] p-1"
-				style={{ background: '#1A1A1C', border: '1px solid #3A3A3C' }}
-			>
+			<div className="flex gap-1 rounded-[20px] p-1 bg-background border border-border">
 				{TABS.map(({ value, label }) => (
 					<button
 						key={value}
 						type="button"
 						onClick={() => handleSettingsTabChange(value)}
-						className="flex-1 rounded-[16px] py-2.5 text-[11px] font-semibold tracking-[1.5px] transition-colors"
-						style={
-							activeTab === value
-								? { background: '#C9A962', color: '#1A1A1C' }
-								: { color: '#4A4A4C' }
-						}
+						className={`flex-1 rounded-[16px] py-2.5 text-[11px] font-semibold tracking-[1.5px] transition-colors ${activeTab === value ? 'bg-gold text-background' : 'text-tertiary'}`}
 					>
 						{label}
 					</button>


### PR DESCRIPTION
## Summary
- Replaced remaining inline `style={{ ... }}` hex/rgba colors with design system tokens across Settings tabs, InstallBanner, MilestoneModal overlay, and LogPrayers overlay
- Replaced the prayer row height magic number (`height: 72`) with the canonical Tailwind class `h-18`
- Strictly typed the backup import destructures in `db/queries.ts` with `PrayerLog` / `PrayerDebt` / `Objective` (no more `any`)
- Documented the legitimate `any` usages in `useProximitySensor.ts` with `biome-ignore` comments (non-standard browser APIs: ProximitySensor, DeviceProximityEvent)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test:run` passes (152/152)
- [ ] Visual check: Settings tabs, Install banner, Milestone modal, LogPrayers modal still look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied design-system color tokens throughout the app for enhanced visual consistency across settings, installation prompts, and overlays.

* **Refactor**
  * Improved type safety for backup import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->