### PR TITLE
perf(activity-calendar): memoize grid + fix timezone

### DIFF
--- a/src/components/ActivityCalendar.tsx
+++ b/src/components/ActivityCalendar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { db } from '@/db/database';
 import { getActivityByDay } from '@/db/queries';
@@ -35,43 +35,44 @@ export function ActivityCalendar() {
 		return () => document.removeEventListener('pointerdown', onPointerDown);
 	}, []);
 
-	const today = new Date();
-	today.setHours(0, 0, 0, 0);
-	const todayDow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
-	const startDate = new Date(today);
-	startDate.setDate(today.getDate() - todayDow - (WEEKS - 1) * 7);
+	const { cells, monthLabels, hasData } = useMemo(() => {
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+		const todayDow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
+		const startDate = new Date(today);
+		startDate.setDate(today.getDate() - todayDow - (WEEKS - 1) * 7);
 
-	// Build cells[week][dow]
-	const cells: Array<Array<{ date: string; count: number; isFuture: boolean }>> = [];
-	for (let week = 0; week < WEEKS; week++) {
-		const weekCells = [];
-		for (let dow = 0; dow < 7; dow++) {
-			const d = new Date(startDate);
-			d.setDate(startDate.getDate() + week * 7 + dow);
-			const isFuture = d > today;
-			const dateStr = d.toISOString().slice(0, 10);
-			weekCells.push({ date: dateStr, count: activityMap.get(dateStr) ?? 0, isFuture });
+		const cells: Array<Array<{ date: string; count: number; isFuture: boolean }>> = [];
+		for (let week = 0; week < WEEKS; week++) {
+			const weekCells = [];
+			for (let dow = 0; dow < 7; dow++) {
+				const d = new Date(startDate);
+				d.setDate(startDate.getDate() + week * 7 + dow);
+				const isFuture = d > today;
+				const dateStr = d.toISOString().slice(0, 10);
+				weekCells.push({ date: dateStr, count: activityMap.get(dateStr) ?? 0, isFuture });
+			}
+			cells.push(weekCells);
 		}
-		cells.push(weekCells);
-	}
 
-	const hasData = cells.some((week) => week.some((cell) => !cell.isFuture && cell.count > 0));
+		const hasData = cells.some((week) => week.some((cell) => !cell.isFuture && cell.count > 0));
 
-	// Month labels: show month abbrev at the first week of each month
-	const monthLabels: (string | null)[] = Array(WEEKS).fill(null);
-	for (let week = 0; week < WEEKS; week++) {
-		const firstCell = cells[week][0];
-		if (firstCell && !firstCell.isFuture) {
-			const d = new Date(firstCell.date);
-			if (d.getDate() <= 7) {
-				monthLabels[week] = d.toLocaleString(i18n.language, { month: 'short' });
+		const monthLabels: (string | null)[] = Array(WEEKS).fill(null);
+		for (let week = 0; week < WEEKS; week++) {
+			const firstCell = cells[week][0];
+			if (firstCell && !firstCell.isFuture) {
+				const d = new Date(`${firstCell.date}T00:00:00`);
+				if (d.getDate() <= 7) {
+					monthLabels[week] = d.toLocaleString(i18n.language, { month: 'short' });
+				}
 			}
 		}
-	}
+
+		return { cells, monthLabels, hasData };
+	}, [activityMap, i18n.language]);
 
 	return (
 		<div ref={containerRef} className="flex flex-col gap-2">
-			{/* Tooltip */}
 			<div style={{ minHeight: 18 }}>
 				{selected && (
 					<p className="text-center text-[11px] text-muted">
@@ -89,7 +90,6 @@ export function ActivityCalendar() {
 				)}
 			</div>
 
-			{/* Month labels row */}
 			<div
 				style={{
 					display: 'grid',

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.9',
+		date: '2026-04-15',
+		changes: {
+			fr: [
+				"Perf : mémorisation du calcul de la grille d'activité — évite 112 créations de Date et conversions ISO à chaque sélection de cellule",
+				"Fix : correction d'un bug de fuseau horaire dans les étiquettes de mois du calendrier d'activité",
+			],
+			en: [
+				'Perf: memoized activity calendar grid computation — avoids 112 Date allocations and ISO conversions on every cell selection',
+				'Fix: timezone bug in activity calendar month labels',
+			],
+		},
+	},
+	{
 		version: '1.30.8',
 		date: '2026-04-15',
 		changes: {


### PR DESCRIPTION
## Summary
- Memoize `cells` / `monthLabels` / `hasData` in `ActivityCalendar` — avoids 112 `Date` allocations and `toISOString` conversions on every cell selection toggle (only recomputes when `activityMap` or locale changes).
- Fix timezone bug in month-label detection: `new Date(firstCell.date)` parsed ISO strings as UTC, causing `getDate()` to return the wrong day on negative-UTC offsets near month boundaries. Now uses `T00:00:00` suffix — matches the pattern already used in the tooltip.
- Remove self-describing JSX comments (`{/* Tooltip */}`, `{/* Month labels row */}`); keep the grid-iteration comment since it explains non-obvious row-major traversal.

## Test plan
- [x] `pnpm run build` passes (type-check + vite build)
- [x] `pnpm run lint` clean
- [ ] Visual check: activity calendar renders identically; month labels appear on correct weeks
- [ ] Selecting a cell no longer re-runs the full grid computation (verifiable via React DevTools Profiler)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone-related issue in version 1.30.9.

* **Performance**
  * Improved Activity Calendar rendering performance through optimized computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->