### PR TITLE
fix(build): add .npmrc optional=true to fix rolldown native bindings on Coolify

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+optional=true

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,11 +10,17 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
-		version: '1.30.13',
+		version: '1.30.14',
 		date: '2026-04-15',
 		changes: {
-			fr: ['SEO : ajout du protocole IndexNow — clé de vérification + référence dans robots.txt'],
-			en: ['SEO: added IndexNow protocol — verification key file + reference in robots.txt'],
+			fr: [
+				'Fix : ajout de .npmrc (optional=true) pour corriger le build Coolify — rolldown ne trouvait pas ses bindings natifs linux-x64',
+				'SEO : redirection HTTP→HTTPS 307 → 301 via Traefik redirectscheme.permanent=true (Coolify)',
+			],
+			en: [
+				'Fix: add .npmrc (optional=true) to fix Coolify build — rolldown could not find its linux-x64 native bindings',
+				'SEO: HTTP→HTTPS redirect 307 → 301 via Traefik redirectscheme.permanent=true (Coolify)',
+			],
 		},
 	},
 	{


### PR DESCRIPTION
## Problem

Coolify deployments are failing at `pnpm run build` with:
```
Cannot find native binding. npm has a bug related to optional dependencies.
Please use pnpm or yarn to install rolldown.
```

`pnpm install --frozen-lockfile` in the Docker build environment was skipping the optional platform-specific `@rolldown/binding-linux-x64-gnu` package (marked `optional: true` in the lockfile), causing Vite 8's rolldown bundler to fail.

## Fix

Add `.npmrc` with `optional=true` to force pnpm to always install optional dependencies, including platform-specific native bindings.

## Side effect

This deploy will also activate the Traefik `redirectscheme.permanent=true` label already saved via API — changing the HTTP→HTTPS redirect from **307 → 301**.

## Test plan

- [ ] Coolify deployment succeeds (no rolldown binding error)
- [ ] `curl -sI http://qada.fahari.pro/ | head -3` returns `301`
- [ ] App loads normally at https://qada.fahari.pro/