### PR TITLE
feat(analytics): add 5 new Umami tracking events + share source

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -14,6 +14,8 @@ const ENTRIES: ChangelogEntry[] = [
 		date: '2026-04-16',
 		changes: {
 			fr: [
+				'Analytics : 5 nouveaux events Umami — pwa_install, pwa_install_dismiss, language_change, onboarding_complete, milestone_reached',
+				'Analytics : ajout de la source (dashboard/settings) aux events de partage',
 				'SEO : redirection HTTP→HTTPS permanente (308) via Traefik redirectRegex — correction du conflit de noms de routeurs Coolify',
 				'SEO : ajout de dateCreated au schéma WebSite, mise à jour softwareVersion + dateModified dans WebApplication',
 				"SEO : ajout d'un second profil GitHub (mkldevops) dans Organization.sameAs",
@@ -22,6 +24,8 @@ const ENTRIES: ChangelogEntry[] = [
 				'SEO : ajout du protocole IndexNow — fichier de vérification + meta tag pour indexation rapide (Bing, Yandex)',
 			],
 			en: [
+				'Analytics: 5 new Umami events — pwa_install, pwa_install_dismiss, language_change, onboarding_complete, milestone_reached',
+				'Analytics: added source (dashboard/settings) to share events',
 				'SEO: permanent HTTP→HTTPS redirect (308) via Traefik redirectRegex — fixed Coolify router name conflict',
 				'SEO: added dateCreated to WebSite schema, updated softwareVersion + dateModified in WebApplication',
 				'SEO: added second GitHub profile (mkldevops) to Organization.sameAs',

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'motion/react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { track } from '@/lib/analytics';
 import { type BeforeInstallPromptEvent, dismissInstallBanner } from '@/lib/pwa';
 
 interface InstallBannerProps {
@@ -17,6 +18,7 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 		try {
 			await prompt.prompt();
 			await prompt.userChoice;
+			track({ name: 'pwa_install' });
 			dismissInstallBanner();
 			onDismiss();
 		} catch (error) {
@@ -29,6 +31,7 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 	};
 
 	const handleDismiss = () => {
+		track({ name: 'pwa_install_dismiss' });
 		dismissInstallBanner();
 		onDismiss();
 	};

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -17,8 +17,10 @@ export function InstallBanner({ prompt, onDismiss }: InstallBannerProps) {
 		setIsPrompting(true);
 		try {
 			await prompt.prompt();
-			await prompt.userChoice;
-			track({ name: 'pwa_install' });
+			const { outcome } = await prompt.userChoice;
+			if (outcome === 'accepted') {
+				track({ name: 'pwa_install' });
+			}
 			dismissInstallBanner();
 			onDismiss();
 		} catch (error) {

--- a/src/components/MilestoneModal.tsx
+++ b/src/components/MilestoneModal.tsx
@@ -1,5 +1,7 @@
 import { AnimatePresence, motion } from 'motion/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { track } from '@/lib/analytics';
 import type { Milestone } from '@/types';
 
 interface MilestoneModalProps {
@@ -16,6 +18,16 @@ const MILESTONE_CONFIG: Record<Milestone['kind'], { emoji: string; isYear: boole
 function MilestoneContent({ milestone, onClose }: { milestone: Milestone; onClose: () => void }) {
 	const { t } = useTranslation();
 	const { emoji, isYear } = MILESTONE_CONFIG[milestone.kind];
+
+	useEffect(() => {
+		const value =
+			milestone.kind === 'count'
+				? milestone.value
+				: milestone.kind === 'year'
+					? milestone.years
+					: milestone.months;
+		track({ name: 'milestone_reached', data: { kind: milestone.kind, value } });
+	}, [milestone]);
 	const subtleColor = 'color-mix(in srgb, var(--background) 80%, transparent)';
 
 	let title: string;

--- a/src/components/MilestoneModal.tsx
+++ b/src/components/MilestoneModal.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { track } from '@/lib/analytics';
 import type { Milestone } from '@/types';
@@ -19,15 +19,19 @@ function MilestoneContent({ milestone, onClose }: { milestone: Milestone; onClos
 	const { t } = useTranslation();
 	const { emoji, isYear } = MILESTONE_CONFIG[milestone.kind];
 
+	const value =
+		milestone.kind === 'count'
+			? milestone.value
+			: milestone.kind === 'year'
+				? milestone.years
+				: milestone.months;
+	const trackedRef = useRef('');
 	useEffect(() => {
-		const value =
-			milestone.kind === 'count'
-				? milestone.value
-				: milestone.kind === 'year'
-					? milestone.years
-					: milestone.months;
+		const key = `${milestone.kind}:${value}`;
+		if (trackedRef.current === key) return;
+		trackedRef.current = key;
 		track({ name: 'milestone_reached', data: { kind: milestone.kind, value } });
-	}, [milestone]);
+	}, [milestone.kind, value]);
 	const subtleColor = 'color-mix(in srgb, var(--background) 80%, transparent)';
 
 	let title: string;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -18,7 +18,12 @@ type TrackEvent =
 	| { name: 'reset_all_data' }
 	| { name: 'restart_onboarding'; data: { from: 'settings' | 'dashboard' | 'reset' } }
 	| { name: 'feedback_open' }
-	| { name: 'share'; data: { method: 'native' | 'clipboard' } };
+	| { name: 'share'; data: { method: 'native' | 'clipboard'; source: 'dashboard' | 'settings' } }
+	| { name: 'pwa_install' }
+	| { name: 'pwa_install_dismiss' }
+	| { name: 'language_change'; data: { lang: string } }
+	| { name: 'onboarding_complete' }
+	| { name: 'milestone_reached'; data: { kind: string; value: number } };
 
 export function track(event: TrackEvent): void {
 	const data = 'data' in event ? event.data : undefined;

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -2,7 +2,7 @@ import type { TFunction } from 'i18next';
 import { toast } from 'sonner';
 import { track } from '@/lib/analytics';
 
-export async function handleShare(t: TFunction): Promise<void> {
+export async function handleShare(t: TFunction, source: 'dashboard' | 'settings'): Promise<void> {
 	const shareText = t('settings.shareText');
 	if (!navigator.share) {
 		if (!navigator.clipboard) {
@@ -12,7 +12,7 @@ export async function handleShare(t: TFunction): Promise<void> {
 		try {
 			await navigator.clipboard.writeText(shareText);
 			toast.success(t('settings.shareCopied'));
-			track({ name: 'share', data: { method: 'clipboard' } });
+			track({ name: 'share', data: { method: 'clipboard', source } });
 		} catch {
 			toast.error(t('settings.shareFailed'));
 		}
@@ -24,7 +24,7 @@ export async function handleShare(t: TFunction): Promise<void> {
 			text: shareText,
 			url: 'https://qada.fahari.pro',
 		});
-		track({ name: 'share', data: { method: 'native' } });
+		track({ name: 'share', data: { method: 'native', source } });
 	} catch (err) {
 		if (
 			err instanceof DOMException &&

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -314,7 +314,7 @@ export function Dashboard({ onRestartOnboarding }: { onRestartOnboarding?: () =>
 							</motion.button>
 							<motion.button
 								type="button"
-								onClick={() => handleShare(t)}
+								onClick={() => handleShare(t, 'dashboard')}
 								className="flex flex-1 items-center justify-center gap-2 rounded-[28px] py-4 bg-surface border border-border"
 								whileTap={{ scale: 0.97 }}
 								whileHover={{ scale: 1.01 }}

--- a/src/pages/OnboardingFlow.tsx
+++ b/src/pages/OnboardingFlow.tsx
@@ -6,6 +6,7 @@ import { HaydStepper } from '@/components/HaydStepper';
 import { IslamicReminder } from '@/components/IslamicReminder';
 import { ObjectiveCard } from '@/components/ObjectiveCard';
 import { getPrayerLabel, PRAYER_CONFIG } from '@/constants/prayers';
+import { track } from '@/lib/analytics';
 import { spring, springSnappy } from '@/lib/animations';
 import { calculateSuggestion } from '@/lib/calculateSuggestion';
 import { randomEncouragement } from '@/lib/encouragements';
@@ -895,6 +896,11 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 
+	function handleComplete() {
+		track({ name: 'onboarding_complete' });
+		onComplete();
+	}
+
 	async function handleDebtNext(data: DebtData) {
 		setSaving(true);
 		setSaveError(null);
@@ -938,7 +944,9 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
 		>
 			<div className="mx-auto flex w-full max-w-lg flex-1 flex-col min-h-0 pt-14">
 				<AnimatePresence mode="wait">
-					{step === 'welcome' && <WelcomeStep onNext={() => setStep('debt')} onSkip={onComplete} />}
+					{step === 'welcome' && (
+						<WelcomeStep onNext={() => setStep('debt')} onSkip={handleComplete} />
+					)}
 					{step === 'debt' && (
 						<DebtStep
 							onNext={handleDebtNext}
@@ -950,7 +958,7 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
 					{step === 'objective' && (
 						<ObjectiveStep onNext={handleObjectiveNext} saving={saving} saveError={saveError} />
 					)}
-					{step === 'summary' && <SummaryStep onComplete={onComplete} />}
+					{step === 'summary' && <SummaryStep onComplete={handleComplete} />}
 				</AnimatePresence>
 			</div>
 		</motion.div>

--- a/src/pages/Settings/AppTab.tsx
+++ b/src/pages/Settings/AppTab.tsx
@@ -157,7 +157,10 @@ export function AppTab({ onRestartOnboarding }: { onRestartOnboarding?: () => vo
 							<button
 								key={lang}
 								type="button"
-								onClick={() => i18n.changeLanguage(lang)}
+								onClick={() => {
+									i18n.changeLanguage(lang);
+									track({ name: 'language_change', data: { lang } });
+								}}
 								className={`flex-1 rounded-[16px] py-2.5 text-[13px] font-semibold transition-colors ${
 									i18n.resolvedLanguage === lang
 										? 'bg-gold text-background'
@@ -203,7 +206,7 @@ export function AppTab({ onRestartOnboarding }: { onRestartOnboarding?: () => vo
 					</button>
 					<button
 						type="button"
-						onClick={() => handleShare(t)}
+						onClick={() => handleShare(t, 'settings')}
 						className="flex w-full items-center justify-center gap-2.5 rounded-[28px] py-4 bg-background border border-border"
 					>
 						<Share2 size={16} className="text-gold" />


### PR DESCRIPTION
## Summary
- Add 5 new Umami events: `pwa_install`, `pwa_install_dismiss`, `language_change`, `onboarding_complete`, `milestone_reached`
- Add `source` parameter (`dashboard` | `settings`) to existing `share` event
- Track PWA install banner conversion, language distribution, onboarding funnel, and milestone engagement

## Test plan
- [ ] Trigger share from Dashboard → check Umami shows `source: dashboard`
- [ ] Trigger share from Settings → check Umami shows `source: settings`
- [ ] Click "Install" on PWA banner → verify `pwa_install` event
- [ ] Click "Later" on PWA banner → verify `pwa_install_dismiss` event
- [ ] Switch language in Settings → verify `language_change` with correct `lang`
- [ ] Complete onboarding flow → verify `onboarding_complete` fires
- [ ] Reach a milestone → verify `milestone_reached` with `kind` and `value`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics instrumentation to track user interactions including PWA installation, language changes, milestone milestones, and onboarding completion.
  * Improved share feature tracking to capture context about where sharing is initiated (dashboard or settings).
  * Updated changelog with version 1.30.16 details documenting new analytics events and source tracking for shares.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->