### PR TITLE
feat(session): add rak'a by rak'a mode

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.30.17',
+		date: '2026-04-16',
+		changes: {
+			fr: [
+				"Session : mode rak'a par rak'a — avancez une rak'a à la fois, la prière est loggée après la dernière",
+				"Réglages : le suivi sujoud devient un sous-paramètre du mode rak'a par rak'a",
+			],
+			en: [
+				"Session: rak'a by rak'a mode — advance one rak'a at a time, the prayer is logged after the last one",
+				"Settings: sujood tracking is now a sub-setting of rak'a by rak'a mode",
+			],
+		},
+	},
+	{
 		version: '1.30.16',
 		date: '2026-04-16',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -325,6 +325,7 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const activeObjective = usePrayerStore((s) => s.activeObjective);
 	const sessionOrder = usePrayerStore((s) => s.sessionOrder);
 	const sujoodTrackingEnabled = usePrayerStore((s) => s.sujoodTrackingEnabled);
+	const rakaByRaka = usePrayerStore((s) => s.rakaByRaka);
 	const sessionsPerDay = usePrayerStore((s) => s.sessionsPerDay);
 	const setTashahdDurationMs = usePrayerStore((s) => s.setTashahdDurationMs);
 
@@ -514,7 +515,9 @@ export function Session({ onClose }: { onClose: () => void }) {
 	}
 
 	const handleDone = () => {
-		if (currentRakat > 0) {
+		if (rakaByRaka && !sujoodTrackingEnabled) {
+			handleRakatComplete();
+		} else if (currentRakat > 0) {
 			setConfirmDone(true);
 		} else {
 			handleIncrement(true);
@@ -934,6 +937,20 @@ export function Session({ onClose }: { onClose: () => void }) {
 												transition={{ duration: 0.8, repeat: Infinity, ease: 'linear' }}
 												className="inline-block w-4 h-4 rounded-full border-2 border-current border-t-transparent"
 											/>
+										</motion.span>
+									) : rakaByRaka &&
+										!sujoodTrackingEnabled &&
+										cfg &&
+										currentRakat < cfg.rakat - 1 ? (
+										<motion.span
+											key={currentRakat}
+											initial={{ opacity: 0 }}
+											animate={{ opacity: 1 }}
+										>
+											{t('session.rakatProgress', {
+												current: currentRakat + 1,
+												total: cfg.rakat,
+											})}
 										</motion.span>
 									) : (
 										<motion.span key="label" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -179,6 +179,8 @@
 		"prayerOrderDesc": "الترتيب الذي تُؤدَّى فيه الصلوات خلال الجلسة",
 		"chronological": "ترتيب زمني",
 		"highestDebt": "أولوية الفوائت",
+		"rakaByRaka": "ركعة بركعة",
+		"rakaByRakaDesc": "تقدّم ركعةً واحدة في كل مرة — تُسجَّل الصلاة بعد آخر ركعة",
 		"sujoodTracking": "تتبع السجود",
 		"sujoodTrackingDesc": "الكشف التلقائي للسجود عبر مستشعرات الجهاز",
 		"tashahdDuration": "مدة التشهد",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -149,6 +149,8 @@
 		"prayerOrderDesc": "Order in which prayers are offered during session",
 		"chronological": "Chronological",
 		"highestDebt": "Debt priority",
+		"rakaByRaka": "Rak'a by rak'a",
+		"rakaByRakaDesc": "Advance one rak'a at a time — the prayer is logged after the last one",
 		"sujoodTracking": "Sujood tracking",
 		"sujoodTrackingDesc": "Auto-detect sujood via device sensors",
 		"tashahdDuration": "Tashahhud duration",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -149,6 +149,8 @@
 		"prayerOrderDesc": "Ordre dans lequel les prières sont proposées en session",
 		"chronological": "Chronologique",
 		"highestDebt": "Priorité dette",
+		"rakaByRaka": "Rak'a par rak'a",
+		"rakaByRakaDesc": "Avancez une rak'a à la fois — la prière est loggée après la dernière",
 		"sujoodTracking": "Suivi sujoud",
 		"sujoodTrackingDesc": "Détection automatique des sujoud via les capteurs",
 		"tashahdDuration": "Durée du tachahoud",

--- a/src/pages/Settings/SessionTab.tsx
+++ b/src/pages/Settings/SessionTab.tsx
@@ -24,6 +24,8 @@ export function SessionTab() {
 	const {
 		setSessionOrder,
 		sessionOrder,
+		rakaByRaka,
+		setRakaByRaka,
 		sujoodTrackingEnabled,
 		setSujoodTrackingEnabled,
 		tashahdDurationMs,
@@ -65,63 +67,93 @@ export function SessionTab() {
 					<div className="flex items-center justify-between pt-1">
 						<div className="flex flex-col gap-0.5">
 							<span className="text-sm font-medium text-foreground">
-								{t('settings.sujoodTracking')}
+								{t('settings.rakaByRaka')}
 							</span>
-							<span className="text-[11px] text-muted">{t('settings.sujoodTrackingDesc')}</span>
+							<span className="text-[11px] text-muted">{t('settings.rakaByRakaDesc')}</span>
 						</div>
 						<button
 							type="button"
 							role="switch"
-							aria-checked={sujoodTrackingEnabled}
-							aria-label={t('settings.sujoodTracking')}
-							onClick={() => setSujoodTrackingEnabled(!sujoodTrackingEnabled)}
+							aria-checked={rakaByRaka}
+							aria-label={t('settings.rakaByRaka')}
+							onClick={() => setRakaByRaka(!rakaByRaka)}
 							className="relative flex shrink-0 items-center rounded-lg p-2 focus-visible:ring-2 focus-visible:ring-gold focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
 						>
 							<span
-								className={`relative h-7 w-12 rounded-full transition-colors ${sujoodTrackingEnabled ? 'bg-gold' : 'bg-border'}`}
+								className={`relative h-7 w-12 rounded-full transition-colors ${rakaByRaka ? 'bg-gold' : 'bg-border'}`}
 							>
 								<span
 									className="absolute top-1 h-5 w-5 rounded-full bg-foreground transition-all"
-									style={{ left: sujoodTrackingEnabled ? '50%' : '4px' }}
+									style={{ left: rakaByRaka ? '50%' : '4px' }}
 								/>
 							</span>
 						</button>
 					</div>
-					{sujoodTrackingEnabled && (
+					{rakaByRaka && (
 						<>
 							<div className="h-px bg-border" />
 							<div className="flex items-center justify-between">
 								<div className="flex flex-col gap-0.5">
 									<span className="text-sm font-medium text-foreground">
-										{t('settings.tashahdDuration')}
+										{t('settings.sujoodTracking')}
 									</span>
-									<span className="text-[11px] text-muted">
-										{t('settings.tashahdDurationDesc')}
-									</span>
+									<span className="text-[11px] text-muted">{t('settings.sujoodTrackingDesc')}</span>
 								</div>
-								<div className="flex items-center gap-2">
-									<button
-										type="button"
-										onClick={() => setTashahdDurationMs(tashahdDurationMs - 5000)}
-										disabled={tashahdDurationMs <= 5000}
-										className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
+								<button
+									type="button"
+									role="switch"
+									aria-checked={sujoodTrackingEnabled}
+									aria-label={t('settings.sujoodTracking')}
+									onClick={() => setSujoodTrackingEnabled(!sujoodTrackingEnabled)}
+									className="relative flex shrink-0 items-center rounded-lg p-2 focus-visible:ring-2 focus-visible:ring-gold focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+								>
+									<span
+										className={`relative h-7 w-12 rounded-full transition-colors ${sujoodTrackingEnabled ? 'bg-gold' : 'bg-border'}`}
 									>
-										−
-									</button>
-									<span className="min-w-[48px] text-center text-sm font-semibold tabular-nums text-foreground">
-										{Math.round(tashahdDurationMs / 1000)}
-										<span className="text-muted font-normal text-xs ms-0.5">s</span>
+										<span
+											className="absolute top-1 h-5 w-5 rounded-full bg-foreground transition-all"
+											style={{ left: sujoodTrackingEnabled ? '50%' : '4px' }}
+										/>
 									</span>
-									<button
-										type="button"
-										onClick={() => setTashahdDurationMs(tashahdDurationMs + 5000)}
-										disabled={tashahdDurationMs >= 300000}
-										className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
-									>
-										+
-									</button>
-								</div>
+								</button>
 							</div>
+							{sujoodTrackingEnabled && (
+								<>
+									<div className="h-px bg-border" />
+									<div className="flex items-center justify-between">
+										<div className="flex flex-col gap-0.5">
+											<span className="text-sm font-medium text-foreground">
+												{t('settings.tashahdDuration')}
+											</span>
+											<span className="text-[11px] text-muted">
+												{t('settings.tashahdDurationDesc')}
+											</span>
+										</div>
+										<div className="flex items-center gap-2">
+											<button
+												type="button"
+												onClick={() => setTashahdDurationMs(tashahdDurationMs - 5000)}
+												disabled={tashahdDurationMs <= 5000}
+												className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
+											>
+												−
+											</button>
+											<span className="min-w-[48px] text-center text-sm font-semibold tabular-nums text-foreground">
+												{Math.round(tashahdDurationMs / 1000)}
+												<span className="text-muted font-normal text-xs ms-0.5">s</span>
+											</span>
+											<button
+												type="button"
+												onClick={() => setTashahdDurationMs(tashahdDurationMs + 5000)}
+												disabled={tashahdDurationMs >= 300000}
+												className="w-8 h-8 rounded-full flex items-center justify-center text-lg font-medium text-foreground bg-background border border-border disabled:opacity-30"
+											>
+												+
+											</button>
+										</div>
+									</div>
+								</>
+							)}
 						</>
 					)}
 					{activeObjective && (

--- a/src/stores/prayerStore.ts
+++ b/src/stores/prayerStore.ts
@@ -166,9 +166,14 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 			return raw === 'chronological' || raw === 'highest-debt' ? raw : 'chronological';
 		})(),
 		sujoodTrackingEnabled: localStorage.getItem(SUJOOD_TRACKING_KEY) === 'true',
-		rakaByRaka:
-			localStorage.getItem(RAKA_BY_RAKA_KEY) === 'true' ||
-			localStorage.getItem(SUJOOD_TRACKING_KEY) === 'true',
+		rakaByRaka: (() => {
+			if (localStorage.getItem(RAKA_BY_RAKA_KEY) === 'true') return true;
+			if (localStorage.getItem(SUJOOD_TRACKING_KEY) === 'true') {
+				localStorage.setItem(RAKA_BY_RAKA_KEY, 'true');
+				return true;
+			}
+			return false;
+		})(),
 		sessionsPerDay: (() => {
 			const raw = parseInt(localStorage.getItem(SESSIONS_PER_DAY_KEY) ?? '', 10);
 			return [1, 2, 3, 4, 5].includes(raw) ? raw : 1;
@@ -249,7 +254,12 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 
 		setSujoodTrackingEnabled: (enabled) => {
 			localStorage.setItem(SUJOOD_TRACKING_KEY, String(enabled));
-			set({ sujoodTrackingEnabled: enabled });
+			if (enabled && !get().rakaByRaka) {
+				localStorage.setItem(RAKA_BY_RAKA_KEY, 'true');
+				set({ sujoodTrackingEnabled: true, rakaByRaka: true });
+			} else {
+				set({ sujoodTrackingEnabled: enabled });
+			}
 		},
 
 		setRakaByRaka: (enabled) => {

--- a/src/stores/prayerStore.ts
+++ b/src/stores/prayerStore.ts
@@ -102,6 +102,7 @@ export type SessionOrder = 'chronological' | 'highest-debt';
 
 const SESSION_ORDER_KEY = 'session-order';
 const SUJOOD_TRACKING_KEY = 'sujood-tracking-enabled';
+const RAKA_BY_RAKA_KEY = 'raka-by-raka-enabled';
 const SESSIONS_PER_DAY_KEY = 'sessions-per-day';
 const TASHAHD_DURATION_KEY = 'tashahd-duration-ms';
 
@@ -113,6 +114,7 @@ interface PrayerStore {
 	isLoading: boolean;
 	sessionOrder: SessionOrder;
 	sujoodTrackingEnabled: boolean;
+	rakaByRaka: boolean;
 	sessionsPerDay: number;
 	tashahdDurationMs: number;
 	pendingMilestone: Milestone | null;
@@ -128,6 +130,7 @@ interface PrayerStore {
 	setObjective: (period: Period, target: number) => Promise<void>;
 	setSessionOrder: (order: SessionOrder) => void;
 	setSujoodTrackingEnabled: (enabled: boolean) => void;
+	setRakaByRaka: (enabled: boolean) => void;
 	setSessionsPerDay: (value: number) => void;
 	setTashahdDurationMs: (ms: number) => void;
 	clearMilestone: () => void;
@@ -163,6 +166,9 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 			return raw === 'chronological' || raw === 'highest-debt' ? raw : 'chronological';
 		})(),
 		sujoodTrackingEnabled: localStorage.getItem(SUJOOD_TRACKING_KEY) === 'true',
+		rakaByRaka:
+			localStorage.getItem(RAKA_BY_RAKA_KEY) === 'true' ||
+			localStorage.getItem(SUJOOD_TRACKING_KEY) === 'true',
 		sessionsPerDay: (() => {
 			const raw = parseInt(localStorage.getItem(SESSIONS_PER_DAY_KEY) ?? '', 10);
 			return [1, 2, 3, 4, 5].includes(raw) ? raw : 1;
@@ -244,6 +250,16 @@ export const usePrayerStore = create<PrayerStore>()((set, get) => {
 		setSujoodTrackingEnabled: (enabled) => {
 			localStorage.setItem(SUJOOD_TRACKING_KEY, String(enabled));
 			set({ sujoodTrackingEnabled: enabled });
+		},
+
+		setRakaByRaka: (enabled) => {
+			localStorage.setItem(RAKA_BY_RAKA_KEY, String(enabled));
+			if (!enabled) {
+				localStorage.setItem(SUJOOD_TRACKING_KEY, 'false');
+				set({ rakaByRaka: false, sujoodTrackingEnabled: false });
+			} else {
+				set({ rakaByRaka: true });
+			}
 		},
 
 		setSessionsPerDay: (value) => {


### PR DESCRIPTION
## Summary
- Add "rak'a by rak'a" toggle in session settings — each tap advances one rak'a, the prayer is logged after the last one
- Sujood tracking is now a sub-setting of rak'a mode (disabling rak'a mode auto-disables sujood tracking)
- Button label shows "Rak'a 1/4", "Rak'a 2/4"... then "TERMINÉ ✓" on the last rak'a
- Backward compatible: existing sujood tracking users get rak'a mode auto-enabled
- i18n: FR, EN, AR translations added

## Test plan
- [ ] Enable "Rak'a par rak'a" in Settings > Session
- [ ] Start a session → button shows "Rak'a 1/4" for a 4-rak'a prayer
- [ ] Tap through each rak'a → dots advance, button updates
- [ ] Last rak'a tap → prayer logged, moves to next prayer
- [ ] Disable rak'a mode → sujood tracking also disabled
- [ ] Enable rak'a + sujood → sujood detection per rak'a (existing behavior)
- [ ] Fresh user with sujood tracking ON → rak'a mode auto-enabled on load