### PR TITLE
refactor(stats): merge loops, safe badge default, conditional weekBadgeTone

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -11,13 +11,14 @@ interface ChangelogEntry {
 const ENTRIES: ChangelogEntry[] = [
 	{
 		version: '1.31.0',
-		date: '2026-04-17',
+		date: '2026-04-18',
 		changes: {
 			fr: [
 				"Stats : nouvelles sections — En ce moment, Cette semaine, Vue d'ensemble",
 				'Stats : nouveaux indicateurs — meilleur streak, record jour/semaine, cohérence 30j, cadence, semaine précédente',
 				'Stats : prochain palier avec progression vers 100 / 500 / 1k / 2.5k / 5k / 10k',
 				'Stats : correction du calcul record semaine avec DST et de la cohérence 30j (bornée à 100 %)',
+				'Stats : fusion des boucles bestDay/bestStreak, badge de semaine conditionnel, StatCard badge sécurisé',
 				"Feedback : ouverture directe du formulaire Tally dans un nouvel onglet au lieu de l'iframe (plus fiable)",
 				'Feedback : ajout de noopener,noreferrer sur les liens externes (sécurité)',
 			],
@@ -26,6 +27,7 @@ const ENTRIES: ChangelogEntry[] = [
 				'Stats: new metrics — best streak, best day/week, 30d consistency, pace, last week',
 				'Stats: next milestone with progress toward 100 / 500 / 1k / 2.5k / 5k / 10k',
 				'Stats: fixed best-week DST bug and 30d consistency (clamped to 100%)',
+				'Stats: merged bestDay/bestStreak loops, conditional week badge tone, safe StatCard badge default',
 				'Feedback: open Tally form directly in a new tab instead of the iframe (more reliable)',
 				'Feedback: added noopener,noreferrer on external links (security)',
 			],

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -38,8 +38,10 @@ export function StatCard({
 				className={`text-3xl font-semibold leading-none tabular-nums ${tone ? TONE_CLASS[tone] : 'text-foreground'}`}
 			>
 				{value}
-				{badge && badgeTone && (
-					<span className={`ms-1 text-[13px] font-medium ${BADGE_CLASS[badgeTone]}`}>{badge}</span>
+				{badge && (
+					<span className={`ms-1 text-[13px] font-medium ${BADGE_CLASS[badgeTone ?? 'sage']}`}>
+						{badge}
+					</span>
 				)}
 			</span>
 			<span className="text-[10px] font-medium text-muted">{label}</span>

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -185,11 +185,6 @@ async function getExtendedTemporalStats(db: QadaDB): Promise<{
 		avgPerDay = logsInWindow > 0 ? logsInWindow / effectiveDays : 0;
 	}
 
-	let bestDay = 0;
-	for (const count of byDate.values()) {
-		if (count > bestDay) bestDay = count;
-	}
-
 	const todayUtcMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
 	let daysWithPrayers = 0;
 	for (let i = 0; i < 30; i++) {
@@ -200,10 +195,14 @@ async function getExtendedTemporalStats(db: QadaDB): Promise<{
 
 	const sortedDates = [...byDate.keys()].sort();
 
+	let bestDay = 0;
 	let bestStreak = 0;
 	let currentRun = 0;
 	let prevMs = 0;
 	for (const dateStr of sortedDates) {
+		const count = byDate.get(dateStr) ?? 0;
+		if (count > bestDay) bestDay = count;
+
 		const ms = new Date(dateStr).getTime();
 		if (prevMs === 0 || ms - prevMs === 86_400_000) {
 			currentRun++;

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -29,7 +29,11 @@ export function Stats() {
 				? `+${weekDelta}`
 				: `${weekDelta}`
 			: undefined;
-	const weekBadgeTone = weekDelta > 0 ? ('sage' as const) : ('danger' as const);
+	const weekBadgeTone = weekBadge
+		? weekDelta > 0
+			? ('sage' as const)
+			: ('danger' as const)
+		: undefined;
 
 	const pace = stats.avgPerDay > 0 ? (stats.avgPerDay * 30) / 150 : 0;
 


### PR DESCRIPTION
Apply code review suggestions from #187:

- `queries.ts`: merged `bestDay` into `sortedDates` loop — removes a separate `byDate.values()` iteration
- `StatCard`: `badge` without `badgeTone` now defaults to `'sage'` instead of silent no-op
- `Stats.tsx`: `weekBadgeTone` computed only when `weekBadge` is defined (was always evaluated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed badge display to appear with a default visual style when no specific tone is specified, rather than requiring explicit styling configuration.

* **Improvements**
  * Enhanced stat calculation accuracy and improved consistency between badge and badge-tone behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->