### PR TITLE
style(public): fix CSS/JS indentation in about and privacy

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -35,66 +35,66 @@
     </script>
     <style>
       :root {
-              --bg: #1a1a1c;
-              --surface: #242426;
-              --border: #3a3a3c;
-              --text: #f5f5f0;
-              --muted: #6e6e70;
-              --gold: #c9a962;
-            }
-            * { box-sizing: border-box; margin: 0; padding: 0; }
-            body {
-              background: var(--bg);
-              color: var(--text);
-              font-family: Inter, system-ui, sans-serif;
-              font-size: 16px;
-              line-height: 1.7;
-              padding: 2rem 1rem 4rem;
-            }
-            .container { max-width: 680px; margin: 0 auto; }
-            a { color: var(--gold); }
-            a:hover { text-decoration: underline; }
-            header { margin-bottom: 2.5rem; }
-            header a {
-              color: var(--gold);
-              text-decoration: none;
-              font-size: 0.875rem;
-              display: inline-flex;
-              align-items: center;
-              gap: 0.4rem;
-              margin-bottom: 1.5rem;
-            }
-            header a:hover { text-decoration: underline; }
-            h1 { font-size: 1.75rem; font-weight: 600; margin-bottom: 0.5rem; }
-            .subtitle { color: var(--muted); font-size: 0.9rem; }
-            section { margin-top: 2rem; }
-            h2 { font-size: 1.1rem; font-weight: 600; color: var(--gold); margin-bottom: 0.75rem; }
-            p { margin-bottom: 1rem; }
-            ul { padding-left: 1.5rem; margin-bottom: 1rem; }
-            li { margin-bottom: 0.4rem; }
-            .author-card {
-              display: flex;
-              align-items: center;
-              gap: 1rem;
-              padding: 1.25rem;
-              background: var(--surface);
-              border: 1px solid var(--border);
-              border-radius: 12px;
-              margin: 1.5rem 0;
-            }
-            .author-avatar {
-              width: 56px;
-              height: 56px;
-              border-radius: 50%;
-              background: var(--border);
-              display: flex;
-              align-items: center;
-              justify-content: center;
-              font-size: 1.5rem;
-              flex-shrink: 0;
-            }
-            .author-name { font-weight: 600; margin-bottom: 0.2rem; }
-            .author-role { color: var(--muted); font-size: 0.875rem; }
+        --bg: #1a1a1c;
+        --surface: #242426;
+        --border: #3a3a3c;
+        --text: #f5f5f0;
+        --muted: #6e6e70;
+        --gold: #c9a962;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: Inter, system-ui, sans-serif;
+        font-size: 16px;
+        line-height: 1.7;
+        padding: 2rem 1rem 4rem;
+      }
+      .container { max-width: 680px; margin: 0 auto; }
+      a { color: var(--gold); }
+      a:hover { text-decoration: underline; }
+      header { margin-bottom: 2.5rem; }
+      header a {
+        color: var(--gold);
+        text-decoration: none;
+        font-size: 0.875rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-bottom: 1.5rem;
+      }
+      header a:hover { text-decoration: underline; }
+      h1 { font-size: 1.75rem; font-weight: 600; margin-bottom: 0.5rem; }
+      .subtitle { color: var(--muted); font-size: 0.9rem; }
+      section { margin-top: 2rem; }
+      h2 { font-size: 1.1rem; font-weight: 600; color: var(--gold); margin-bottom: 0.75rem; }
+      p { margin-bottom: 1rem; }
+      ul { padding-left: 1.5rem; margin-bottom: 1rem; }
+      li { margin-bottom: 0.4rem; }
+      .author-card {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1.25rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        margin: 1.5rem 0;
+      }
+      .author-avatar {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        background: var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.5rem;
+        flex-shrink: 0;
+      }
+      .author-name { font-weight: 600; margin-bottom: 0.2rem; }
+      .author-role { color: var(--muted); font-size: 0.875rem; }
     </style>
   </head>
   <body>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -8,56 +8,56 @@
     <link rel="canonical" href="https://qada.fahari.pro/privacy" />
     <style>
       :root {
-              --bg: #1a1a1c;
-              --surface: #242426;
-              --border: #3a3a3c;
-              --text: #f5f5f0;
-              --muted: #6e6e70;
-              --gold: #c9a962;
-            }
-            * { box-sizing: border-box; margin: 0; padding: 0; }
-            body {
-              background: var(--bg);
-              color: var(--text);
-              font-family: Inter, system-ui, sans-serif;
-              font-size: 16px;
-              line-height: 1.7;
-              padding: 2rem 1rem 4rem;
-            }
-            .container { max-width: 680px; margin: 0 auto; }
-            header { margin-bottom: 2.5rem; }
-            header a {
-              color: var(--gold);
-              text-decoration: none;
-              font-size: 0.875rem;
-              display: inline-flex;
-              align-items: center;
-              gap: 0.4rem;
-              margin-bottom: 1.5rem;
-            }
-            header a:hover { text-decoration: underline; }
-            h1 { font-size: 1.75rem; font-weight: 600; margin-bottom: 0.5rem; }
-            .subtitle { color: var(--muted); font-size: 0.9rem; }
-            section { margin-top: 2rem; }
-            h2 { font-size: 1.1rem; font-weight: 600; color: var(--gold); margin-bottom: 0.75rem; }
-            p { margin-bottom: 1rem; }
-            ul { padding-left: 1.5rem; margin-bottom: 1rem; }
-            li { margin-bottom: 0.4rem; }
-            .badge {
-              display: inline-block;
-              background: var(--surface);
-              border: 1px solid var(--border);
-              border-radius: 6px;
-              padding: 0.75rem 1rem;
-              font-size: 0.9rem;
-              color: var(--muted);
-              margin-bottom: 1rem;
-              width: 100%;
-            }
-            .badge strong { color: var(--text); }
-            footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.85rem; }
-            footer a { color: var(--gold); text-decoration: none; }
-            footer a:hover { text-decoration: underline; }
+        --bg: #1a1a1c;
+        --surface: #242426;
+        --border: #3a3a3c;
+        --text: #f5f5f0;
+        --muted: #6e6e70;
+        --gold: #c9a962;
+      }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: Inter, system-ui, sans-serif;
+        font-size: 16px;
+        line-height: 1.7;
+        padding: 2rem 1rem 4rem;
+      }
+      .container { max-width: 680px; margin: 0 auto; }
+      header { margin-bottom: 2.5rem; }
+      header a {
+        color: var(--gold);
+        text-decoration: none;
+        font-size: 0.875rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-bottom: 1.5rem;
+      }
+      header a:hover { text-decoration: underline; }
+      h1 { font-size: 1.75rem; font-weight: 600; margin-bottom: 0.5rem; }
+      .subtitle { color: var(--muted); font-size: 0.9rem; }
+      section { margin-top: 2rem; }
+      h2 { font-size: 1.1rem; font-weight: 600; color: var(--gold); margin-bottom: 0.75rem; }
+      p { margin-bottom: 1rem; }
+      ul { padding-left: 1.5rem; margin-bottom: 1rem; }
+      li { margin-bottom: 0.4rem; }
+      .badge {
+        display: inline-block;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.75rem 1rem;
+        font-size: 0.9rem;
+        color: var(--muted);
+        margin-bottom: 1rem;
+        width: 100%;
+      }
+      .badge strong { color: var(--text); }
+      footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.85rem; }
+      footer a { color: var(--gold); text-decoration: none; }
+      footer a:hover { text-decoration: underline; }
     </style>
   </head>
   <body>
@@ -135,9 +135,9 @@
         </p>
         <script>
           fetch('/version.json').then(r => r.json()).then(d => {
-                      const el = document.getElementById('ver');
-                      if (el) el.textContent = d.version;
-                    }).catch(() => {});
+            const el = document.getElementById('ver');
+            if (el) el.textContent = d.version;
+          }).catch(() => {});
         </script>
       </footer>
     </div>

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,14 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.33.0',
+		date: '2026-04-18',
+		changes: {
+			fr: ['Pages publiques : correction de l’indentation CSS/JS dans about.html et privacy.html'],
+			en: ['Public pages: fixed CSS/JS indentation in about.html and privacy.html'],
+		},
+	},
+	{
 		version: '1.31.0',
 		date: '2026-04-18',
 		changes: {


### PR DESCRIPTION
## Summary
- Normalize over-indented CSS rules inside `<style>` blocks in `public/about.html` and `public/privacy.html`
- Fix the over-indented version-fetch script in `public/privacy.html`
- Pure formatting change — no behavioral or visual impact

## Test plan
- [ ] Verify pages render identically at `/about` and `/privacy` after build
- [ ] `pnpm run build` succeeds