### PR TITLE
perf(session): memoize rakats computation and stabilize callbacks

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,20 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.33.2',
+		date: '2026-04-18',
+		changes: {
+			fr: [
+				'Session : mémoïsation du calcul des rak’a restantes et stabilisation des callbacks',
+				'Saisie : stabilisation du handler de quantité pour éviter les re-rendus inutiles',
+			],
+			en: [
+				'Session: memoized remaining rak’a computation and stabilized callbacks',
+				'Log prayers: stabilized quantity handler to avoid unnecessary re-renders',
+			],
+		},
+	},
+	{
 		version: '1.33.0',
 		date: '2026-04-18',
 		changes: {

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2, Minus, Plus, Timer } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { EncouragementMessage } from '@/components/EncouragementMessage';
@@ -247,7 +247,6 @@ function AnimatedCounter({
 				</motion.button>
 			</div>
 
-			{/* Progress bar */}
 			<div
 				className="w-full h-1 rounded-full overflow-hidden"
 				style={{ background: 'var(--surface-raised)' }}
@@ -283,7 +282,6 @@ function PrayerCard({
 			exit={{ scale: 0.85, opacity: 0, y: -20 }}
 			transition={springBouncy}
 		>
-			{/* Glow background */}
 			<motion.div
 				className="absolute inset-0"
 				style={{
@@ -338,11 +336,14 @@ export function Session({ onClose }: { onClose: () => void }) {
 	const [targetDir, setTargetDir] = useState<1 | -1>(1);
 	const [userEdited, setUserEdited] = useState(false);
 
-	function changeTarget(v: number) {
-		setTargetDir(v >= target ? 1 : -1);
-		setTarget(v);
-		setUserEdited(true);
-	}
+	const changeTarget = useCallback(
+		(v: number) => {
+			setTargetDir(v >= target ? 1 : -1);
+			setTarget(v);
+			setUserEdited(true);
+		},
+		[target],
+	);
 
 	useEffect(() => {
 		if (userEdited || phase !== 'setup') return;
@@ -568,20 +569,22 @@ export function Session({ onClose }: { onClose: () => void }) {
 	}
 
 	const sessionPrayersRemaining = target - completed;
-	let sessionRakatsRemaining = 0;
-	if (phase === 'active' && sessionPrayersRemaining > 0) {
+	const sessionRakatsRemaining = useMemo(() => {
+		if (phase !== 'active' || sessionPrayersRemaining <= 0) return 0;
 		let count = 0;
 		let i = 0;
+		let total = 0;
 		const maxIter = prayerOrder.length * sessionPrayersRemaining + prayerOrder.length;
 		while (count < sessionPrayersRemaining && i < maxIter) {
 			const prayer = prayerOrder[(currentPrayerIndex + i) % prayerOrder.length];
 			if ((debts[prayer]?.remaining ?? 0) > 0) {
-				sessionRakatsRemaining += PRAYER_CONFIG[prayer].rakat;
+				total += PRAYER_CONFIG[prayer].rakat;
 				count++;
 			}
 			i++;
 		}
-	}
+		return total;
+	}, [phase, sessionPrayersRemaining, prayerOrder, currentPrayerIndex, debts]);
 	const effectiveRakatsRemaining = Math.max(0, sessionRakatsRemaining - currentRakat);
 
 	const currentEntry =

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -1,6 +1,6 @@
 import { Check, Minus, Plus, RotateCcw, Trash2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
@@ -571,9 +571,9 @@ export function LogPrayers() {
 		setActiveTab(tab);
 	}
 
-	function handleChange(prayer: PrayerName, qty: number) {
+	const handleChange = useCallback((prayer: PrayerName, qty: number) => {
 		setQuantities((prev) => ({ ...prev, [prayer]: Math.max(0, qty) }));
-	}
+	}, []);
 
 	async function handleLog() {
 		const entries: BatchEntry[] = PRAYER_NAMES.map((prayer) => ({


### PR DESCRIPTION
## Summary
- **Session.tsx**: wrap the O(n) remaining-rakats loop in `useMemo` so it only recomputes when debts/phase/target change
- **Session.tsx**: stabilize `changeTarget` with `useCallback` (prevents child re-renders on every parent render)
- **Session.tsx**: remove two redundant JSX comments
- **LogPrayers.tsx**: stabilize `handleChange` with `useCallback` (empty-deps, pure setter)

No behavioral changes — purely performance hygiene for React 19 without React Compiler enabled.

## Test plan
- [x] `pnpm run build` passes (tsc -b + vite build)
- [x] `pnpm run lint` clean (only pre-existing warnings, no new ones)
- [ ] Session flow: start, change target, complete rakats — verify counters match previous behavior
- [ ] LogPrayers: increment/decrement quantities — verify state updates correctly