### PR TITLE
feat(log): undo toast after each prayer log

### DIFF
--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -10,6 +10,18 @@ interface ChangelogEntry {
 
 const ENTRIES: ChangelogEntry[] = [
 	{
+		version: '1.33.3',
+		date: '2026-04-30',
+		changes: {
+			fr: [
+				'Logger : toast de confirmation après chaque log avec bouton Annuler pour corriger un tap accidentel',
+			],
+			en: [
+				'Log: confirmation toast after each log with an Undo button to correct an accidental tap',
+			],
+		},
+	},
+	{
 		version: '1.33.2',
 		date: '2026-04-30',
 		changes: {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -118,6 +118,8 @@
 		"totalCount_other": "{{count}} صلاة",
 		"confirm": "تأكيد التسجيل",
 		"emptyHistory": "لا سجل مُدوَّن",
+		"undoToast": "تم تسجيل الصلاة",
+		"undoAction": "تراجع",
 		"undoLast": "تراجع عن الأخير",
 		"undoTitle": "التراجع عن آخر إدخال؟",
 		"undoDesc": "يحذف الجلسة الأخيرة ويحدّث العدادات.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -92,6 +92,8 @@
 		"totalCount_other": "{{count}} prayers",
 		"confirm": "CONFIRM LOG",
 		"emptyHistory": "No log recorded",
+		"undoToast": "Prayer logged",
+		"undoAction": "Undo",
 		"undoLast": "Undo last",
 		"undoTitle": "Undo last entry?",
 		"undoDesc": "Deletes the last session and updates the counters.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -92,6 +92,8 @@
 		"totalCount_other": "{{count}} prières",
 		"confirm": "CONFIRMER LE LOG",
 		"emptyHistory": "Aucun log enregistré",
+		"undoToast": "Prière loggée",
+		"undoAction": "Annuler",
 		"undoLast": "Annuler le dernier",
 		"undoTitle": "Annuler la dernière entrée ?",
 		"undoDesc": "Supprime la dernière session et remet les compteurs à jour.",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ function PrayerRow({
 	totalOwed,
 	totalCompleted,
 	onLog,
+	onUndo,
 	index = 0,
 }: {
 	prayer: PrayerName;
@@ -36,6 +37,7 @@ function PrayerRow({
 	totalOwed: number;
 	totalCompleted: number;
 	onLog: (p: PrayerName) => void;
+	onUndo: () => Promise<void>;
 	index?: number;
 }) {
 	const { t, i18n } = useTranslation();
@@ -70,6 +72,10 @@ function PrayerRow({
 			if (!shouldReduce) {
 				setJustLogged(true);
 			}
+			toast(t('log.undoToast'), {
+				duration: 5000,
+				action: { label: t('log.undoAction'), onClick: onUndo },
+			});
 		} catch (err) {
 			if (import.meta.env.DEV) console.error('logPrayer failed', err);
 			toast.error(t('common.error'));
@@ -151,7 +157,7 @@ function PrayerRow({
 
 export function Dashboard({ onRestartOnboarding }: { onRestartOnboarding?: () => void }) {
 	const { t, i18n } = useTranslation();
-	const { logPrayer } = usePrayerStore();
+	const { logPrayer, undoLastLog } = usePrayerStore();
 	const debts = useDebts();
 	const stats = useStats();
 	const activeObjective = useActiveObjective();
@@ -285,6 +291,7 @@ export function Dashboard({ onRestartOnboarding }: { onRestartOnboarding?: () =>
 									totalOwed={debts[prayer]?.total_owed ?? 0}
 									totalCompleted={debts[prayer]?.total_completed ?? 0}
 									onLog={logPrayer}
+									onUndo={undoLastLog}
 									index={index}
 								/>
 							))}

--- a/src/pages/LogPrayers.tsx
+++ b/src/pages/LogPrayers.tsx
@@ -585,6 +585,10 @@ export function LogPrayers() {
 		track({ name: 'prayers_logged', data: { total } });
 		setQuantities(EMPTY());
 		switchTab('history');
+		toast(t('log.undoToast'), {
+			duration: 5000,
+			action: { label: t('log.undoAction'), onClick: undoLastLog },
+		});
 	}
 
 	return (


### PR DESCRIPTION
## Summary

- After every prayer log (Dashboard `+` button or Log page confirm), a 5-second toast appears at the top with an **Undo** button
- Tapping Undo calls `undoLastLog()` which rolls back the last session — directly addressing user feedback: "It would be great to have an option to deduct a prayer, in case if i accidentally clicked"
- No new infrastructure needed — Sonner was already configured in `App.tsx`

## Test plan

- [ ] Tap `+` on any prayer in Dashboard → toast appears, tap Undo → count rolls back
- [ ] Log a batch in Log tab → toast appears, tap Undo → counts roll back
- [ ] Toast auto-dismisses after 5s with no action
- [ ] Works in FR, EN, AR